### PR TITLE
Implement petty cash module with always-visible sidebar

### DIFF
--- a/app/Http/Controllers/PettyCashExpenseController.php
+++ b/app/Http/Controllers/PettyCashExpenseController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PettyCashExpense;
+use Illuminate\Http\Request;
+
+class PettyCashExpenseController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'role:admin,cajero']);
+    }
+
+    public function index()
+    {
+        $expenses = PettyCashExpense::latest()->get();
+        return view('petty_cash.index', compact('expenses'));
+    }
+
+    public function create()
+    {
+        return view('petty_cash.create');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'description' => 'required|string|max:255',
+            'amount' => 'required|numeric|min:0.01',
+        ]);
+
+        PettyCashExpense::create([
+            'user_id' => auth()->id(),
+            'description' => $request->description,
+            'amount' => $request->amount,
+        ]);
+
+        return redirect()->route('petty-cash.index')
+            ->with('success', 'Gasto registrado correctamente.');
+    }
+
+    public function destroy(PettyCashExpense $pettyCash)
+    {
+        $pettyCash->delete();
+        return redirect()->route('petty-cash.index')
+            ->with('success', 'Gasto eliminado correctamente.');
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -6,10 +6,16 @@
     </x-slot>
 
     <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900">
-                    {{ __("You're logged in!") }}
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <a href="{{ route('tickets.create') }}" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Nuevo Ticket</a>
+            </div>
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <h3 class="text-lg font-semibold mb-2">Reportes (próximamente)</h3>
+                <div class="flex gap-4">
+                    <button class="px-4 py-2 bg-gray-300 text-gray-700 rounded" disabled>Reporte Diario</button>
+                    <button class="px-4 py-2 bg-gray-300 text-gray-700 rounded" disabled>Reporte Mensual</button>
                 </div>
             </div>
         </div>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -1,4 +1,4 @@
-<aside class="w-48 bg-white border-r border-gray-200 hidden sm:block">
+<aside class="w-48 bg-white border-r border-gray-200">
     <div class="p-4">
         <nav class="space-y-2">
             <a href="{{ route('dashboard') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('dashboard') ? 'bg-gray-200' : '' }}">
@@ -15,6 +15,9 @@
             </a>
             <a href="{{ route('tickets.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('tickets.*') ? 'bg-gray-200' : '' }}">
                 Tickets
+            </a>
+            <a href="{{ route('petty-cash.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('petty-cash.*') ? 'bg-gray-200' : '' }}">
+                Caja Chica
             </a>
             <a href="{{ route('profile.edit') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('profile.*') ? 'bg-gray-200' : '' }}">
                 Perfil

--- a/resources/views/petty_cash/create.blade.php
+++ b/resources/views/petty_cash/create.blade.php
@@ -1,0 +1,39 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Registrar Gasto de Caja Chica') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-4">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
+            @if ($errors->any())
+                <div class="mb-4 text-sm text-red-600">
+                    <ul class="list-disc list-inside">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            <form method="POST" action="{{ route('petty-cash.store') }}">
+                @csrf
+                <div class="mb-4">
+                    <label for="description" class="block font-medium text-sm text-gray-700">Descripción</label>
+                    <input type="text" name="description" id="description" required class="form-input w-full rounded border-gray-300 shadow-sm mt-1">
+                </div>
+
+                <div class="mb-4">
+                    <label for="amount" class="block font-medium text-sm text-gray-700">Monto</label>
+                    <input type="number" step="0.01" name="amount" id="amount" required class="form-input w-full rounded border-gray-300 shadow-sm mt-1">
+                </div>
+
+                <div class="flex justify-end">
+                    <a href="{{ route('petty-cash.index') }}" class="mr-3 px-4 py-2 bg-gray-300 text-gray-700 rounded">Cancelar</a>
+                    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Guardar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/petty_cash/index.blade.php
+++ b/resources/views/petty_cash/index.blade.php
@@ -1,0 +1,46 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Caja Chica') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+        @if (session('success'))
+            <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
+        @endif
+
+        <div class="mb-4">
+            <a href="{{ route('petty-cash.create') }}" class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600">Nuevo Gasto</a>
+        </div>
+
+        <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+            <table class="min-w-full table-auto border">
+                <thead class="bg-gray-200">
+                    <tr>
+                        <th class="border px-4 py-2">Fecha</th>
+                        <th class="border px-4 py-2">Descripción</th>
+                        <th class="border px-4 py-2">Monto</th>
+                        <th class="border px-4 py-2">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($expenses as $expense)
+                        <tr class="border-t">
+                            <td class="px-4 py-2">{{ $expense->created_at->format('d/m/Y H:i') }}</td>
+                            <td class="px-4 py-2">{{ $expense->description }}</td>
+                            <td class="px-4 py-2">RD$ {{ number_format($expense->amount, 2) }}</td>
+                            <td class="px-4 py-2">
+                                <form action="{{ route('petty-cash.destroy', $expense) }}" method="POST" onsubmit="return confirm('¿Eliminar este gasto?')">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-red-600 hover:underline">Eliminar</button>
+                                </form>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\ServiceController;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\WasherController;
 use App\Http\Controllers\TicketController;
+use App\Http\Controllers\PettyCashExpenseController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -39,5 +40,6 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
 });
 Route::middleware(['auth', 'role:admin,cajero'])->group(function () {
     Route::resource('tickets', TicketController::class)->except(['show']);
+    Route::resource('petty-cash', PettyCashExpenseController::class)->except(['show', 'edit', 'update']);
 });
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- manage petty cash records with `PettyCashExpenseController`
- list and create petty cash views
- add petty cash routes and sidebar link
- add dashboard shortcut buttons
- remove `hidden sm:block` so sidebar appears on small screens

## Testing
- `php artisan route:list`
- `vendor/bin/phpunit --testdox` *(fails: 24 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b9ddaab28832a986bce4bc533acad