### PR TITLE
Add pricing management to services

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -31,7 +31,7 @@ class TicketController extends Controller
     public function create()
     {
         return view('tickets.create', [
-            'services' => Service::all(),
+            'services' => Service::where('active', true)->get(),
             'vehicleTypes' => VehicleType::all(),
             'products' => Product::where('stock', '>', 0)->get(),
             'washers' => Washer::all(),
@@ -62,7 +62,10 @@ class TicketController extends Controller
 
             // Servicios
             foreach ($request->service_ids as $serviceId) {
-                $service = Service::find($serviceId);
+                $service = Service::where('active', true)->find($serviceId);
+                if (!$service) {
+                    continue;
+                }
                 $priceRow = $service->prices()->where('vehicle_type_id', $vehicleType->id)->first();
                 $price = $priceRow ? $priceRow->price : 0;
 

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -9,7 +9,7 @@ class Service extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'description'];
+    protected $fillable = ['name', 'description', 'active'];
 
     public function prices()
     {

--- a/database/migrations/2025_06_13_190347_add_active_to_services_table.php
+++ b/database/migrations/2025_06_13_190347_add_active_to_services_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('services', function (Blueprint $table) {
+            $table->boolean('active')->default(true)->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('services', function (Blueprint $table) {
+            $table->dropColumn('active');
+        });
+    }
+};

--- a/database/seeders/ServicePriceSeeder.php
+++ b/database/seeders/ServicePriceSeeder.php
@@ -14,12 +14,34 @@ class ServicePriceSeeder extends Seeder
         $services = Service::all();
         $vehicles = VehicleType::all();
 
+        $basePrices = [
+            1 => 100, // Bicicleta
+            2 => 150, // Motor
+            3 => 160, // Pasola
+            4 => 250, // Carro
+            5 => 300, // Jeepeta
+            6 => 350, // Camioneta
+            7 => 400, // Minibús
+            8 => 450, // Guagua
+            9 => 500, // Camión
+        ];
+
+        $serviceIncrement = [
+            1 => 0,
+            2 => 50,
+            3 => 30,
+            4 => 60,
+            5 => 80,
+        ];
+
         foreach ($services as $service) {
             foreach ($vehicles as $vehicle) {
+                $price = ($basePrices[$vehicle->id] ?? 0) + ($serviceIncrement[$service->id] ?? 0);
+
                 ServicePrice::create([
                     'service_id' => $service->id,
                     'vehicle_type_id' => $vehicle->id,
-                    'price' => rand(350, 600)
+                    'price' => $price,
                 ]);
             }
         }

--- a/database/seeders/ServiceSeeder.php
+++ b/database/seeders/ServiceSeeder.php
@@ -20,7 +20,8 @@ class ServiceSeeder extends Seeder
         foreach ($services as $name) {
             Service::create([
                 'name' => $name,
-                'description' => $name . ' para todo tipo de vehículo.'
+                'description' => $name . ' para todo tipo de vehículo.',
+                'active' => true
             ]);
         }
     }

--- a/resources/views/services/create.blade.php
+++ b/resources/views/services/create.blade.php
@@ -14,9 +14,24 @@
                 <input type="text" name="name" required class="form-input w-full">
             </div>
 
+           <div>
+               <label for="description" class="block font-medium text-sm text-gray-700">Descripción</label>
+               <textarea name="description" class="form-input w-full"></textarea>
+           </div>
+
             <div>
-                <label for="description" class="block font-medium text-sm text-gray-700">Descripción</label>
-                <textarea name="description" class="form-input w-full"></textarea>
+                <label class="block font-medium text-sm text-gray-700 mb-1">Precios por tipo de vehículo</label>
+                @foreach ($vehicleTypes as $type)
+                    <div class="flex items-center gap-2 mb-1">
+                        <span class="w-32">{{ $type->name }}</span>
+                        <input type="number" name="prices[{{ $type->id }}]" step="0.01" required class="form-input w-full">
+                    </div>
+                @endforeach
+            </div>
+
+            <div class="flex items-center">
+                <label class="mr-2 text-sm">Activo</label>
+                <input type="checkbox" name="active" value="1" checked>
             </div>
 
 

--- a/resources/views/services/edit.blade.php
+++ b/resources/views/services/edit.blade.php
@@ -16,8 +16,22 @@
             </div>
 
             <div>
-                <label for="description" class="block font-medium text-sm text-gray-700">Descripci¨®n</label>
+                <label for="description" class="block font-medium text-sm text-gray-700">Descripción</label>
                 <textarea name="description" class="form-input w-full">{{ $service->description }}</textarea>
+            </div>
+            <div>
+                <label class="block font-medium text-sm text-gray-700 mb-1">Precios por tipo de vehículo</label>
+                @foreach ($vehicleTypes as $type)
+                    <div class="flex items-center gap-2 mb-1">
+                        <span class="w-32">{{ $type->name }}</span>
+                        <input type="number" name="prices[{{ $type->id }}]" step="0.01" value="{{ $prices[$type->id] ?? '' }}" required class="form-input w-full">
+                    </div>
+                @endforeach
+            </div>
+
+            <div class="flex items-center">
+                <label class="mr-2 text-sm">Activo</label>
+                <input type="checkbox" name="active" value="1" @checked($service->active)>
             </div>
 
             <div class="flex items-center gap-4">

--- a/resources/views/services/index.blade.php
+++ b/resources/views/services/index.blade.php
@@ -28,6 +28,7 @@
                     <tr>
                         <th class="px-4 py-2 border">Nombre</th>
                         <th class="px-4 py-2 border">Descripción</th>
+                        <th class="px-4 py-2 border">Estado</th>
                         <th class="px-4 py-2 border">Acciones</th>
                     </tr>
                 </thead>
@@ -36,6 +37,7 @@
                         <tr class="border-t">
                             <td class="px-4 py-2">{{ $service->name }}</td>
                             <td class="px-4 py-2">{{ $service->description }}</td>
+                            <td class="px-4 py-2">{{ $service->active ? 'Activo' : 'Inactivo' }}</td>
                             <td class="px-4 py-2 flex gap-2">
                                 @if (auth()->user()->role === 'admin')
                                     <a href="{{ route('services.edit', $service) }}"


### PR DESCRIPTION
## Summary
- allow configuring service prices per vehicle type
- enable/disable services
- seed default prices for services
- show service status in listings
- use only active services during ticket creation
- migration for new `active` column

## Testing
- `php artisan migrate:fresh --seed`
- `php artisan test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_684c757fb45c832a8a7788292f8362e7