### PR TITLE
Add drinks module and integrate with tickets

### DIFF
--- a/app/Http/Controllers/DrinkController.php
+++ b/app/Http/Controllers/DrinkController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Drink;
+use Illuminate\Http\Request;
+
+class DrinkController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'role:admin,cajero'])->only('index');
+        $this->middleware(['auth', 'role:admin'])->except('index');
+    }
+
+    public function index(Request $request)
+    {
+        $query = Drink::query();
+
+        if ($request->filled('q')) {
+            $query->where('name', 'like', '%' . $request->q . '%');
+        }
+
+        $drinks = $query->orderBy('name')->get();
+
+        if ($request->ajax()) {
+            return view('drinks.partials.table', [
+                'drinks' => $drinks,
+            ]);
+        }
+
+        return view('drinks.index', [
+            'drinks' => $drinks,
+            'filters' => $request->only('q'),
+        ]);
+    }
+
+    public function create()
+    {
+        return view('drinks.create');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:drinks,name',
+            'price' => 'required|numeric|min:0',
+            'ingredients' => 'nullable|string',
+        ]);
+
+        Drink::create($request->only('name', 'price', 'ingredients'));
+
+        return redirect()->route('drinks.index')
+            ->with('success', 'Trago creado exitosamente.');
+    }
+
+    public function edit(Drink $drink)
+    {
+        return view('drinks.edit', compact('drink'));
+    }
+
+    public function update(Request $request, Drink $drink)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:drinks,name,' . $drink->id,
+            'price' => 'required|numeric|min:0',
+            'ingredients' => 'nullable|string',
+        ]);
+
+        $drink->update($request->only('name', 'price', 'ingredients'));
+
+        return redirect()->route('drinks.index')
+            ->with('success', 'Trago actualizado correctamente.');
+    }
+
+    public function destroy(Drink $drink)
+    {
+        $drink->delete();
+
+        return redirect()->route('drinks.index')
+            ->with('success', 'Trago eliminado correctamente.');
+    }
+}

--- a/app/Http/Controllers/DrinkController.php
+++ b/app/Http/Controllers/DrinkController.php
@@ -46,6 +46,12 @@ class DrinkController extends Controller
             'name' => 'required|string|max:255|unique:drinks,name',
             'price' => 'required|numeric|min:0',
             'ingredients' => 'nullable|string',
+        ], [
+            'name.required' => 'El nombre del trago es obligatorio.',
+            'name.unique' => 'Ya existe un trago con ese nombre.',
+            'price.required' => 'El precio es obligatorio.',
+            'price.numeric' => 'El precio debe ser un número válido.',
+            'price.min' => 'El precio no puede ser negativo.',
         ]);
 
         Drink::create($request->only('name', 'price', 'ingredients'));
@@ -65,6 +71,12 @@ class DrinkController extends Controller
             'name' => 'required|string|max:255|unique:drinks,name,' . $drink->id,
             'price' => 'required|numeric|min:0',
             'ingredients' => 'nullable|string',
+        ], [
+            'name.required' => 'El nombre del trago es obligatorio.',
+            'name.unique' => 'Ya existe un trago con ese nombre.',
+            'price.required' => 'El precio es obligatorio.',
+            'price.numeric' => 'El precio debe ser un número válido.',
+            'price.min' => 'El precio no puede ser negativo.',
         ]);
 
         $drink->update($request->only('name', 'price', 'ingredients'));

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -22,7 +22,7 @@ class TicketController extends Controller
 
     public function index(Request $request)
     {
-        $query = Ticket::where('canceled', false);
+        $query = Ticket::with('details')->where('canceled', false);
 
         if ($request->filled('start')) {
             $query->whereDate('created_at', '>=', $request->start);
@@ -48,7 +48,7 @@ class TicketController extends Controller
 
     public function canceled(Request $request)
     {
-        $query = Ticket::where('canceled', true);
+        $query = Ticket::with('details')->where('canceled', true);
 
         if ($request->filled('start')) {
             $query->whereDate('created_at', '>=', $request->start);
@@ -104,6 +104,8 @@ class TicketController extends Controller
     public function store(Request $request)
     {
         $request->validate([
+            'customer_name' => 'required|string|max:255',
+            'customer_cedula' => 'nullable|string|max:50',
             'vehicle_type_id' => 'nullable|exists:vehicle_types,id',
             'washer_id' => 'nullable|exists:washers,id',
             'service_ids' => 'nullable|array',
@@ -211,6 +213,8 @@ class TicketController extends Controller
                 'user_id' => auth()->id(),
                 'washer_id' => $request->washer_id,
                 'vehicle_type_id' => $request->vehicle_type_id,
+                'customer_name' => $request->customer_name,
+                'customer_cedula' => $request->customer_cedula,
                 'total_amount' => $total,
                 'paid_amount' => $request->paid_amount,
                 'change' => $request->paid_amount - $total,

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -201,12 +201,20 @@ class TicketController extends Controller
 
             if (count($details) === 0) {
                 DB::rollBack();
-                return back()->withErrors(['service_ids' => 'Debe agregar al menos un servicio, producto o trago'])->withInput();
+                $message = ['service_ids' => ['Debe agregar al menos un servicio, producto o trago']];
+                if ($request->expectsJson()) {
+                    return response()->json(['errors' => $message], 422);
+                }
+                return back()->withErrors($message)->withInput();
             }
 
             if ($request->paid_amount < $total) {
                 DB::rollBack();
-                return back()->withErrors(['paid_amount' => 'El monto pagado es menor al total a pagar'])->withInput();
+                $message = ['paid_amount' => ['El monto pagado es menor al total a pagar']];
+                if ($request->expectsJson()) {
+                    return response()->json(['errors' => $message], 422);
+                }
+                return back()->withErrors($message)->withInput();
             }
 
             $ticket = Ticket::create([

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -120,6 +120,21 @@ class TicketController extends Controller
             'drink_quantities.*' => 'integer|min:1',
             'payment_method' => 'required|in:efectivo,tarjeta,transferencia,mixto',
             'paid_amount' => 'required|numeric|min:0'
+        ], [
+            'customer_name.required' => 'El nombre del cliente es obligatorio.',
+            'customer_name.max' => 'El nombre del cliente es demasiado largo.',
+            'customer_cedula.max' => 'La cédula es demasiado larga.',
+            'vehicle_type_id.exists' => 'El tipo de vehículo seleccionado no es válido.',
+            'washer_id.exists' => 'El lavador seleccionado no es válido.',
+            'service_ids.*.exists' => 'Alguno de los servicios seleccionados es inválido.',
+            'product_ids.*.exists' => 'Alguno de los productos seleccionados es inválido.',
+            'quantities.*.min' => 'La cantidad debe ser al menos 1.',
+            'drink_ids.*.exists' => 'Alguno de los tragos seleccionados es inválido.',
+            'drink_quantities.*.min' => 'La cantidad debe ser al menos 1.',
+            'payment_method.required' => 'Debe seleccionar un método de pago.',
+            'paid_amount.required' => 'Debe ingresar el monto pagado.',
+            'paid_amount.numeric' => 'El monto pagado debe ser un número válido.',
+            'paid_amount.min' => 'El monto pagado no puede ser negativo.'
         ]);
 
         DB::beginTransaction();

--- a/app/Models/Drink.php
+++ b/app/Models/Drink.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Drink extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'ingredients', 'price'];
+}

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -11,6 +11,7 @@ class Ticket extends Model
 
     protected $fillable = [
         'user_id', 'washer_id', 'vehicle_type_id',
+        'customer_name', 'customer_cedula',
         'total_amount', 'paid_amount', 'change', 'payment_method', 'canceled'
     ];
 

--- a/app/Models/TicketDetail.php
+++ b/app/Models/TicketDetail.php
@@ -3,6 +3,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\Drink;
 
 class TicketDetail extends Model
 {
@@ -10,7 +11,7 @@ class TicketDetail extends Model
 
     protected $fillable = [
         'ticket_id', 'type', 'service_id',
-        'product_id', 'quantity', 'unit_price', 'subtotal'
+        'product_id', 'drink_id', 'quantity', 'unit_price', 'subtotal'
     ];
 
     public function ticket()
@@ -26,5 +27,10 @@ class TicketDetail extends Model
     public function product()
     {
         return $this->belongsTo(Product::class);
+    }
+
+    public function drink()
+    {
+        return $this->belongsTo(Drink::class);
     }
 }

--- a/database/migrations/2025_06_14_203500_create_drinks_table.php
+++ b/database/migrations/2025_06_14_203500_create_drinks_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('drinks', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->text('ingredients')->nullable();
+            $table->decimal('price', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('drinks');
+    }
+};

--- a/database/migrations/2025_06_14_203524_add_drink_to_ticket_details_table.php
+++ b/database/migrations/2025_06_14_203524_add_drink_to_ticket_details_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ticket_details', function (Blueprint $table) {
+            $table->foreignId('drink_id')->nullable()->after('product_id')->constrained()->onDelete('set null');
+        });
+
+        if (DB::getDriverName() !== 'sqlite') {
+            DB::statement("ALTER TABLE ticket_details MODIFY type ENUM('service','product','drink')");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ticket_details', function (Blueprint $table) {
+            $table->dropForeign(['drink_id']);
+            $table->dropColumn('drink_id');
+        });
+
+        if (DB::getDriverName() !== 'sqlite') {
+            DB::statement("ALTER TABLE ticket_details MODIFY type ENUM('service','product')");
+        }
+    }
+};

--- a/database/migrations/2025_06_14_210727_add_customer_info_to_tickets_table.php
+++ b/database/migrations/2025_06_14_210727_add_customer_info_to_tickets_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->string('customer_name')->after('vehicle_type_id');
+            $table->string('customer_cedula')->nullable()->after('customer_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->dropColumn(['customer_name', 'customer_cedula']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
             ServicePriceSeeder::class,
             ProductSeeder::class,
             WasherSeeder::class,
+            DrinkSeeder::class,
         ]);
     }
 

--- a/database/seeders/DrinkSeeder.php
+++ b/database/seeders/DrinkSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class DrinkSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $drinks = [
+            [
+                'name' => 'Margarita',
+                'ingredients' => 'Tequila, sal y limón.',
+                'price' => 300,
+            ],
+            [
+                'name' => 'Mojito',
+                'ingredients' => 'Hoja de menta, limón, ron blanco, azúcar y 7up.',
+                'price' => 300,
+            ],
+            [
+                'name' => 'Sangría',
+                'ingredients' => 'Vino tinto, jugo de naranja, jugo de limón y soda (agua con gas).',
+                'price' => 350,
+            ],
+            [
+                'name' => 'Gin Tonic',
+                'ingredients' => 'Ginebra y agua tónica, decorada con aceitunas.',
+                'price' => 350,
+            ],
+        ];
+
+        foreach ($drinks as $drink) {
+            \App\Models\Drink::create($drink);
+        }
+    }
+}

--- a/database/seeders/DrinkSeeder.php
+++ b/database/seeders/DrinkSeeder.php
@@ -36,7 +36,7 @@ class DrinkSeeder extends Seeder
         ];
 
         foreach ($drinks as $drink) {
-            \App\Models\Drink::create($drink);
+            \App\Models\Drink::updateOrCreate(['name' => $drink['name']], $drink);
         }
     }
 }

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -21,11 +21,10 @@ class ProductSeeder extends Seeder
         ];
 
         foreach ($products as $item) {
-            Product::create([
-                'name' => $item['name'],
-                'price' => $item['price'],
-                'stock' => 100
-            ]);
+            Product::updateOrCreate(
+                ['name' => $item['name']],
+                ['price' => $item['price'], 'stock' => 100]
+            );
         }
     }
 }

--- a/database/seeders/ServicePriceSeeder.php
+++ b/database/seeders/ServicePriceSeeder.php
@@ -38,11 +38,10 @@ class ServicePriceSeeder extends Seeder
             foreach ($vehicles as $vehicle) {
                 $price = ($basePrices[$vehicle->id] ?? 0) + ($serviceIncrement[$service->id] ?? 0);
 
-                ServicePrice::create([
-                    'service_id' => $service->id,
-                    'vehicle_type_id' => $vehicle->id,
-                    'price' => $price,
-                ]);
+                ServicePrice::updateOrCreate(
+                    ['service_id' => $service->id, 'vehicle_type_id' => $vehicle->id],
+                    ['price' => $price]
+                );
             }
         }
     }

--- a/database/seeders/ServiceSeeder.php
+++ b/database/seeders/ServiceSeeder.php
@@ -18,11 +18,10 @@ class ServiceSeeder extends Seeder
         ];
 
         foreach ($services as $name) {
-            Service::create([
-                'name' => $name,
-                'description' => $name . ' para todo tipo de vehículo.',
-                'active' => true
-            ]);
+            Service::updateOrCreate(
+                ['name' => $name],
+                ['description' => $name . ' para todo tipo de vehículo.', 'active' => true]
+            );
         }
     }
 }

--- a/database/seeders/VehicleTypeSeeder.php
+++ b/database/seeders/VehicleTypeSeeder.php
@@ -15,7 +15,7 @@ class VehicleTypeSeeder extends Seeder
         ];
 
         foreach ($types as $type) {
-            VehicleType::create(['name' => $type]);
+            VehicleType::firstOrCreate(['name' => $type]);
         }
     }
 }

--- a/database/seeders/WasherSeeder.php
+++ b/database/seeders/WasherSeeder.php
@@ -18,7 +18,7 @@ class WasherSeeder extends Seeder
 
         foreach ($washers as $washer) {
             $washer['pending_amount'] = 0;
-            Washer::create($washer);
+            Washer::updateOrCreate(['name' => $washer['name']], $washer);
         }
     }
 }

--- a/resources/views/drinks/create.blade.php
+++ b/resources/views/drinks/create.blade.php
@@ -1,0 +1,36 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Agregar Trago') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6 max-w-4xl mx-auto sm:px-6 lg:px-8">
+        <form action="{{ route('drinks.store') }}" method="POST" class="space-y-6">
+            @csrf
+
+            <div>
+                <label for="name" class="block font-medium text-sm text-gray-700">Nombre</label>
+                <input type="text" name="name" required class="form-input w-full">
+            </div>
+
+
+            <div>
+                <label for="ingredients" class="block font-medium text-sm text-gray-700">Ingredientes</label>
+                <textarea name="ingredients" class="form-input w-full"></textarea>
+            </div>
+
+            <div>
+                <label for="price" class="block font-medium text-sm text-gray-700">Precio (RD$)</label>
+                <input type="number" step="0.01" name="price" required class="form-input w-full">
+            </div>
+
+            <div class="flex items-center gap-4">
+                <button class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
+                    Guardar
+                </button>
+                <a href="{{ route('drinks.index') }}" class="text-gray-600 hover:underline">Cancelar</a>
+            </div>
+        </form>
+    </div>
+</x-app-layout>

--- a/resources/views/drinks/edit.blade.php
+++ b/resources/views/drinks/edit.blade.php
@@ -1,0 +1,35 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Editar Trago') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6 max-w-4xl mx-auto sm:px-6 lg:px-8">
+        <form action="{{ route('drinks.update', $drink) }}" method="POST" class="space-y-6">
+            @csrf
+            @method('PUT')
+
+            <div>
+                <label for="name" class="block font-medium text-sm text-gray-700">Nombre</label>
+                <input type="text" name="name" value="{{ $drink->name }}" required class="form-input w-full">
+            </div>
+            <div>
+                <label for="ingredients" class="block font-medium text-sm text-gray-700">Ingredientes</label>
+                <textarea name="ingredients" class="form-input w-full">{{ $drink->ingredients }}</textarea>
+            </div>
+
+            <div>
+                <label for="price" class="block font-medium text-sm text-gray-700">Precio (RD$)</label>
+                <input type="number" step="0.01" name="price" value="{{ $drink->price }}" required class="form-input w-full">
+            </div>
+
+            <div class="flex items-center gap-4">
+                <button class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+                    Actualizar
+                </button>
+                <a href="{{ route('drinks.index') }}" class="text-gray-600 hover:underline">Cancelar</a>
+            </div>
+        </form>
+    </div>
+</x-app-layout>

--- a/resources/views/drinks/index.blade.php
+++ b/resources/views/drinks/index.blade.php
@@ -1,0 +1,77 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Tragos Disponibles') }}
+        </h2>
+    </x-slot>
+
+    <div x-data="filterTable('{{ route('drinks.index') }}', {selected: null})" x-on:click.away="selected = null" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+
+        @if (session('success'))
+            <div class="mb-4 font-medium text-sm text-green-600">
+                {{ session('success') }}
+            </div>
+        @endif
+
+        @if (auth()->user()->role === 'admin')
+            <div class="mb-4 flex items-center gap-4">
+                <a href="{{ route('drinks.create') }}"
+                   class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">
+                    Nuevo Trago
+                </a>
+                <button x-show="selected" x-on:click="$dispatch('open-modal', 'edit-' + selected)" class="text-yellow-600" title="Editar">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 3.487a2.1 2.1 0 113 3L6.75 19.5H3v-3.75L16.862 3.487z" />
+                    </svg>
+                </button>
+                <button x-show="selected" x-on:click="$dispatch('open-modal', 'delete-' + selected)" class="text-red-600" title="Eliminar">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        @endif
+
+        <form method="GET" x-ref="form" class="mb-4">
+            <input type="text" name="q" value="{{ $filters['q'] ?? '' }}" placeholder="Buscar trago" class="form-input" @input.debounce.500ms="fetchTable()">
+        </form>
+
+        <div x-html="tableHtml"></div>
+        @foreach ($drinks as $drink)
+            <x-modal name="edit-{{ $drink->id }}" focusable>
+                <form method="POST" action="{{ route('drinks.update', $drink) }}" class="p-6 space-y-6">
+                    @csrf
+                    @method('PUT')
+                    <div>
+                        <label class="block font-medium text-sm text-gray-700">Nombre</label>
+                        <input type="text" name="name" value="{{ $drink->name }}" required class="form-input w-full">
+                    </div>
+                    <div>
+                        <label class="block font-medium text-sm text-gray-700">Ingredientes</label>
+                        <textarea name="ingredients" class="form-input w-full">{{ $drink->ingredients }}</textarea>
+                    </div>
+                    <div>
+                        <label class="block font-medium text-sm text-gray-700">Precio (RD$)</label>
+                        <input type="number" step="0.01" name="price" value="{{ $drink->price }}" required class="form-input w-full">
+                    </div>
+                    <div class="mt-6 flex justify-end">
+                        <x-secondary-button x-on:click="$dispatch('close')">Cancelar</x-secondary-button>
+                        <x-primary-button class="ms-3">Actualizar</x-primary-button>
+                    </div>
+                </form>
+            </x-modal>
+
+            <x-modal name="delete-{{ $drink->id }}" focusable>
+                <form method="POST" action="{{ route('drinks.destroy', $drink) }}" class="p-6">
+                    @csrf
+                    @method('DELETE')
+                    <h2 class="text-lg font-medium text-gray-900">¿Eliminar este producto?</h2>
+                    <div class="mt-6 flex justify-end">
+                        <x-secondary-button x-on:click="$dispatch('close')">Cancelar</x-secondary-button>
+                        <x-danger-button class="ms-3">Eliminar</x-danger-button>
+                    </div>
+                </form>
+            </x-modal>
+        @endforeach
+    </div>
+</x-app-layout>

--- a/resources/views/drinks/partials/table.blade.php
+++ b/resources/views/drinks/partials/table.blade.php
@@ -1,0 +1,20 @@
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <table class="min-w-full table-auto border">
+        <thead class="bg-gray-200">
+            <tr>
+                <th class="px-4 py-2 border">Nombre</th>
+                <th class="px-4 py-2 border">Ingredientes</th>
+                <th class="px-4 py-2 border">Precio</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($drinks as $drink)
+                <tr class="border-t cursor-pointer" x-on:click="selected = {{ $drink->id }}" :class="selected === {{ $drink->id }} ? 'bg-blue-100' : ''">
+                    <td class="px-4 py-2">{{ $drink->name }}</td>
+                    <td class="px-4 py-2">{{ $drink->ingredients }}</td>
+                    <td class="px-4 py-2">RD$ {{ number_format($drink->price, 2) }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -10,6 +10,9 @@
             <a href="{{ route('products.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('products.*') ? 'bg-gray-200' : '' }}">
                 Productos
             </a>
+            <a href="{{ route('drinks.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('drinks.*') ? 'bg-gray-200' : '' }}">
+                Tragos
+            </a>
             <a href="{{ route('inventory.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('inventory.*') ? 'bg-gray-200' : '' }}">
                 Inventario
             </a>

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -125,6 +125,15 @@
         const productPrices = @json($productPrices);
         const drinkPrices = @json($drinkPrices);
 
+        let currentTotal = 0;
+
+        function formatCurrency(value) {
+            return value.toLocaleString('es-DO', {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            });
+        }
+
         function updateTotal() {
             const vehicleTypeId = document.querySelector('select[name="vehicle_type_id"]').value;
             let total = 0;
@@ -149,16 +158,17 @@
                 total += price * qty;
             });
 
-            document.getElementById('total_amount').innerText = total.toFixed(2);
+            currentTotal = total;
+            document.getElementById('total_amount').innerText = formatCurrency(total);
             updateChange();
         }
 
         function updateChange() {
-            const total = parseFloat(document.getElementById('total_amount').innerText) || 0;
+            const total = currentTotal;
             const paidField = document.getElementById('paid_amount');
             const paid = paidField.value === '' ? null : parseFloat(paidField.value);
             const change = paid === null ? 0 : paid - total;
-            document.getElementById('change_display').innerText = change.toFixed(2);
+            document.getElementById('change_display').innerText = formatCurrency(change);
         }
 
         function addProductRow() {

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -10,6 +10,15 @@
         <form x-ref="form" action="{{ route('tickets.store') }}" method="POST" @submit.prevent="submitForm" class="space-y-6 pb-32">
             @csrf
 
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Nombre del Cliente</label>
+                <input type="text" name="customer_name" required class="form-input w-full mt-1">
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Cédula</label>
+                <input type="text" name="customer_cedula" class="form-input w-full mt-1">
+            </div>
+
             <!-- Servicios -->
             <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">Servicios</label>
@@ -48,7 +57,7 @@
                     </div>
                 </div>
 
-                <div id="drink-fields" style="display:none" class="mt-4">
+                <div id="drink-fields" class="mt-4">
                     <label class="block text-sm font-medium text-gray-700 mb-1">Tragos Vendidos</label>
                     <div id="drink-list"></div>
                     <button type="button" onclick="addDrinkRow()" class="mt-2 text-sm text-blue-600 hover:underline">+ Agregar trago</button>
@@ -56,7 +65,6 @@
 
                 <div class="mt-2 space-x-4">
                     <button type="button" id="wash-toggle" onclick="toggleWash()" class="text-sm text-blue-600 hover:underline">Agregar Lavado</button>
-                    <button type="button" id="drink-toggle" onclick="toggleDrink()" class="text-sm text-blue-600 hover:underline">Agregar Trago</button>
                 </div>
             </div>
 
@@ -204,20 +212,6 @@
             }
         }
 
-        function toggleDrink() {
-            const drink = document.getElementById('drink-fields');
-            const btn = document.getElementById('drink-toggle');
-            if (drink.style.display === 'none') {
-                drink.style.display = '';
-                btn.textContent = 'Quitar trago';
-            } else {
-                drink.style.display = 'none';
-                btn.textContent = 'Agregar Trago';
-                drink.querySelectorAll('select').forEach(el => el.value = '');
-                drink.querySelectorAll('input[type=number]').forEach(el => el.value = '');
-                updateTotal();
-            }
-        }
 
         document.querySelectorAll('input[name="service_ids[]"], select[name="vehicle_type_id"]').forEach(el => {
             el.addEventListener('change', updateTotal);

--- a/resources/views/tickets/partials/canceled-table.blade.php
+++ b/resources/views/tickets/partials/canceled-table.blade.php
@@ -15,8 +15,8 @@
             @foreach ($tickets as $ticket)
                 <tr class="border-t">
                     <td class="px-4 py-2">{{ $ticket->id }}</td>
-                    <td class="px-4 py-2">{{ $ticket->vehicleType->name }}</td>
-                    <td class="px-4 py-2">{{ $ticket->washer->name }}</td>
+                    <td class="px-4 py-2">{{ optional($ticket->vehicleType)->name ?? '-' }}</td>
+                    <td class="px-4 py-2">{{ optional($ticket->washer)->name ?? '-' }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->total_amount, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->paid_amount, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->change, 2) }}</td>

--- a/resources/views/tickets/partials/canceled-table.blade.php
+++ b/resources/views/tickets/partials/canceled-table.blade.php
@@ -3,8 +3,8 @@
         <thead class="bg-gray-200">
             <tr>
                 <th class="border px-4 py-2">ID</th>
-                <th class="border px-4 py-2">Vehículo</th>
-                <th class="border px-4 py-2">Lavador</th>
+                <th class="border px-4 py-2">Cliente</th>
+                <th class="border px-4 py-2">Facturaciones</th>
                 <th class="border px-4 py-2">Total</th>
                 <th class="border px-4 py-2">Pago</th>
                 <th class="border px-4 py-2">Cambio</th>
@@ -15,8 +15,12 @@
             @foreach ($tickets as $ticket)
                 <tr class="border-t">
                     <td class="px-4 py-2">{{ $ticket->id }}</td>
-                    <td class="px-4 py-2">{{ optional($ticket->vehicleType)->name ?? '-' }}</td>
-                    <td class="px-4 py-2">{{ optional($ticket->washer)->name ?? '-' }}</td>
+                    <td class="px-4 py-2">{{ $ticket->customer_name }}</td>
+                    <td class="px-4 py-2">
+                        {{ $ticket->details->pluck('type')->unique()->map(fn($t) => match($t){
+                            'service' => 'Lavado', 'product' => 'Productos', 'drink' => 'Tragos'
+                        })->implode(', ') }}
+                    </td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->total_amount, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->paid_amount, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->change, 2) }}</td>

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -3,8 +3,8 @@
         <thead class="bg-gray-200">
             <tr>
                 <th class="border px-4 py-2">ID</th>
-                <th class="border px-4 py-2">Vehículo</th>
-                <th class="border px-4 py-2">Lavador</th>
+                <th class="border px-4 py-2">Cliente</th>
+                <th class="border px-4 py-2">Facturaciones</th>
                 <th class="border px-4 py-2">Total</th>
                 <th class="border px-4 py-2">Pago</th>
                 <th class="border px-4 py-2">Cambio</th>
@@ -15,8 +15,12 @@
             @foreach ($tickets as $ticket)
                 <tr class="border-t cursor-pointer" x-on:click="selected = {{ $ticket->id }}" :class="selected === {{ $ticket->id }} ? 'bg-blue-100' : ''">
                     <td class="px-4 py-2">{{ $ticket->id }}</td>
-                    <td class="px-4 py-2">{{ optional($ticket->vehicleType)->name ?? '-' }}</td>
-                    <td class="px-4 py-2">{{ optional($ticket->washer)->name ?? '-' }}</td>
+                    <td class="px-4 py-2">{{ $ticket->customer_name }}</td>
+                    <td class="px-4 py-2">
+                        {{ $ticket->details->pluck('type')->unique()->map(fn($t) => match($t){
+                            'service' => 'Lavado', 'product' => 'Productos', 'drink' => 'Tragos'
+                        })->implode(', ') }}
+                    </td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->total_amount, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->paid_amount, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->change, 2) }}</td>

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -15,8 +15,8 @@
             @foreach ($tickets as $ticket)
                 <tr class="border-t cursor-pointer" x-on:click="selected = {{ $ticket->id }}" :class="selected === {{ $ticket->id }} ? 'bg-blue-100' : ''">
                     <td class="px-4 py-2">{{ $ticket->id }}</td>
-                    <td class="px-4 py-2">{{ $ticket->vehicleType->name }}</td>
-                    <td class="px-4 py-2">{{ $ticket->washer->name }}</td>
+                    <td class="px-4 py-2">{{ optional($ticket->vehicleType)->name ?? '-' }}</td>
+                    <td class="px-4 py-2">{{ optional($ticket->washer)->name ?? '-' }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->total_amount, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->paid_amount, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->change, 2) }}</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ServiceController;
 use App\Http\Controllers\ProductController;
+use App\Http\Controllers\DrinkController;
 use App\Http\Controllers\WasherController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\PettyCashExpenseController;
@@ -37,6 +38,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
 });
 Route::middleware(['auth', 'role:admin,cajero'])->group(function () {
     Route::resource('products', ProductController::class);
+    Route::resource('drinks', DrinkController::class);
     Route::resource('inventory', InventoryMovementController::class)->only(['index', 'create', 'store']);
 });
 Route::middleware(['auth', 'role:admin'])->group(function () {


### PR DESCRIPTION
## Summary
- create Drink model, controller and CRUD views
- seed default drinks and migration for drinks table
- allow tickets to include optional wash and drink details
- update ticket tables to handle missing wash data
- expose drink management routes

## Testing
- `php artisan test` *(fails: No application encryption key specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ddc45163c832a97e2697ac128ea03