### PR TITLE
Add bank accounts module and transfer integration

### DIFF
--- a/app/Http/Controllers/BankAccountController.php
+++ b/app/Http/Controllers/BankAccountController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\BankAccount;
+
+class BankAccountController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'role:admin']);
+    }
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $accounts = BankAccount::orderBy('bank')->get();
+        return view('bank_accounts.index', compact('accounts'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('bank_accounts.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'bank' => 'required|string|max:255',
+            'account' => 'required|string|max:255',
+            'type' => 'required|string|max:255',
+            'holder' => 'required|string|max:255',
+            'holder_cedula' => 'required|string|max:255',
+        ]);
+
+        BankAccount::create($request->only('bank','account','type','holder','holder_cedula'));
+
+        return redirect()->route('bank-accounts.index')
+            ->with('success', 'Cuenta creada correctamente.');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function edit(BankAccount $bankAccount)
+    {
+        return view('bank_accounts.edit', compact('bankAccount'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, BankAccount $bankAccount)
+    {
+        $request->validate([
+            'bank' => 'required|string|max:255',
+            'account' => 'required|string|max:255',
+            'type' => 'required|string|max:255',
+            'holder' => 'required|string|max:255',
+            'holder_cedula' => 'required|string|max:255',
+        ]);
+
+        $bankAccount->update($request->only('bank','account','type','holder','holder_cedula'));
+
+        return redirect()->route('bank-accounts.index')
+            ->with('success', 'Cuenta actualizada correctamente.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(BankAccount $bankAccount)
+    {
+        $bankAccount->delete();
+        return redirect()->route('bank-accounts.index')
+            ->with('success', 'Cuenta eliminada correctamente.');
+    }
+}

--- a/app/Models/BankAccount.php
+++ b/app/Models/BankAccount.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Ticket;
+
+class BankAccount extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'bank',
+        'account',
+        'type',
+        'holder',
+        'holder_cedula',
+    ];
+
+    public function tickets()
+    {
+        return $this->hasMany(Ticket::class);
+    }
+}

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -12,7 +12,7 @@ class Ticket extends Model
     protected $fillable = [
         'user_id', 'washer_id', 'vehicle_type_id',
         'customer_name', 'customer_cedula',
-        'total_amount', 'paid_amount', 'change', 'discount_total', 'payment_method', 'canceled'
+        'total_amount', 'paid_amount', 'change', 'discount_total', 'payment_method', 'bank_account_id', 'canceled'
     ];
 
     protected $casts = [
@@ -37,5 +37,10 @@ class Ticket extends Model
     public function details()
     {
         return $this->hasMany(TicketDetail::class);
+    }
+
+    public function bankAccount()
+    {
+        return $this->belongsTo(BankAccount::class);
     }
 }

--- a/database/migrations/2025_06_15_041105_create_bank_accounts_table.php
+++ b/database/migrations/2025_06_15_041105_create_bank_accounts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('bank_accounts', function (Blueprint $table) {
+            $table->id();
+            $table->string('bank');
+            $table->string('account');
+            $table->string('type');
+            $table->string('holder');
+            $table->string('holder_cedula');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('bank_accounts');
+    }
+};

--- a/database/migrations/2025_06_15_041120_add_bank_account_id_to_tickets_table.php
+++ b/database/migrations/2025_06_15_041120_add_bank_account_id_to_tickets_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            if (!Schema::hasColumn('tickets', 'bank_account_id')) {
+                $table->foreignId('bank_account_id')
+                    ->nullable()
+                    ->after('payment_method')
+                    ->constrained('bank_accounts')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            if (Schema::hasColumn('tickets', 'bank_account_id')) {
+                $table->dropForeign(['bank_account_id']);
+                $table->dropColumn('bank_account_id');
+            }
+        });
+    }
+};

--- a/database/seeders/BankAccountSeeder.php
+++ b/database/seeders/BankAccountSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\BankAccount;
+
+class BankAccountSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        if (BankAccount::count() > 0) {
+            return;
+        }
+
+        $accounts = [
+            [
+                'bank' => 'BHD',
+                'account' => '00123456789',
+                'type' => 'Corriente',
+                'holder' => 'Car Wash S.R.L.',
+                'holder_cedula' => '131-1234567-1',
+            ],
+            [
+                'bank' => 'Banreservas',
+                'account' => '00234567890',
+                'type' => 'Ahorro',
+                'holder' => 'Car Wash S.R.L.',
+                'holder_cedula' => '131-1234567-1',
+            ],
+            [
+                'bank' => 'Popular',
+                'account' => '00345678901',
+                'type' => 'Corriente',
+                'holder' => 'Car Wash S.R.L.',
+                'holder_cedula' => '131-1234567-1',
+            ],
+        ];
+
+        foreach ($accounts as $account) {
+            BankAccount::firstOrCreate(
+                ['bank' => $account['bank'], 'account' => $account['account']],
+                $account
+            );
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Database\Seeders\BankAccountSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -20,6 +21,7 @@ class DatabaseSeeder extends Seeder
             WasherSeeder::class,
             DrinkSeeder::class,
             DiscountSeeder::class,
+            BankAccountSeeder::class,
         ]);
     }
 

--- a/resources/views/bank_accounts/create.blade.php
+++ b/resources/views/bank_accounts/create.blade.php
@@ -1,0 +1,49 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Nueva Cuenta Bancaria') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-4">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
+            @if ($errors->any())
+                <div class="mb-4 text-sm text-red-600">
+                    <ul class="list-disc list-inside">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            <form method="POST" action="{{ route('bank-accounts.store') }}">
+                @csrf
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Banco</label>
+                    <input type="text" name="bank" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Cuenta</label>
+                    <input type="text" name="account" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Tipo</label>
+                    <input type="text" name="type" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Titular</label>
+                    <input type="text" name="holder" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Cédula Titular</label>
+                    <input type="text" name="holder_cedula" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="flex justify-end">
+                    <a href="{{ route('bank-accounts.index') }}" class="mr-3 px-4 py-2 bg-gray-300 text-gray-700 rounded">Cancelar</a>
+                    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Guardar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/bank_accounts/edit.blade.php
+++ b/resources/views/bank_accounts/edit.blade.php
@@ -1,0 +1,50 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Editar Cuenta Bancaria') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-4">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
+            @if ($errors->any())
+                <div class="mb-4 text-sm text-red-600">
+                    <ul class="list-disc list-inside">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            <form method="POST" action="{{ route('bank-accounts.update', $bankAccount) }}">
+                @csrf
+                @method('PUT')
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Banco</label>
+                    <input type="text" name="bank" value="{{ old('bank', $bankAccount->bank) }}" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Cuenta</label>
+                    <input type="text" name="account" value="{{ old('account', $bankAccount->account) }}" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Tipo</label>
+                    <input type="text" name="type" value="{{ old('type', $bankAccount->type) }}" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Titular</label>
+                    <input type="text" name="holder" value="{{ old('holder', $bankAccount->holder) }}" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="mb-4">
+                    <label class="block font-medium text-sm text-gray-700">Cédula Titular</label>
+                    <input type="text" name="holder_cedula" value="{{ old('holder_cedula', $bankAccount->holder_cedula) }}" required class="form-input w-full rounded border-gray-300 mt-1">
+                </div>
+                <div class="flex justify-end">
+                    <a href="{{ route('bank-accounts.index') }}" class="mr-3 px-4 py-2 bg-gray-300 text-gray-700 rounded">Cancelar</a>
+                    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Guardar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/bank_accounts/index.blade.php
+++ b/resources/views/bank_accounts/index.blade.php
@@ -1,0 +1,57 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Cuentas Bancarias') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-4">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @if (session('success'))
+                <div class="mb-4 font-medium text-sm text-green-600">
+                    {{ session('success') }}
+                </div>
+            @endif
+
+            <div class="flex justify-end mb-4">
+                <a href="{{ route('bank-accounts.create') }}" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                    Nueva Cuenta
+                </a>
+            </div>
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <table class="min-w-full table-auto border">
+                    <thead class="bg-gray-200">
+                        <tr>
+                            <th class="px-4 py-2">Banco</th>
+                            <th class="px-4 py-2">Cuenta</th>
+                            <th class="px-4 py-2">Tipo</th>
+                            <th class="px-4 py-2">Titular</th>
+                            <th class="px-4 py-2">Cédula</th>
+                            <th class="px-4 py-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($accounts as $account)
+                            <tr class="border-b">
+                                <td class="px-4 py-2">{{ $account->bank }}</td>
+                                <td class="px-4 py-2">{{ $account->account }}</td>
+                                <td class="px-4 py-2">{{ $account->type }}</td>
+                                <td class="px-4 py-2">{{ $account->holder }}</td>
+                                <td class="px-4 py-2">{{ $account->holder_cedula }}</td>
+                                <td class="px-4 py-2 text-right space-x-2">
+                                    <a href="{{ route('bank-accounts.edit', $account) }}" class="text-blue-600 hover:underline">Editar</a>
+                                    <form action="{{ route('bank-accounts.destroy', $account) }}" method="POST" class="inline">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="text-red-600 hover:underline" onclick="return confirm('¿Eliminar cuenta?')">Eliminar</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -94,11 +94,21 @@
             <!-- Método de Pago -->
             <div>
                 <label class="block text-sm font-medium text-gray-700">Método de Pago</label>
-                <select name="payment_method" required class="form-select w-full mt-1">
+                <select name="payment_method" id="payment_method" required class="form-select w-full mt-1" onchange="toggleBank()">
                     <option value="efectivo">Efectivo</option>
                     <option value="tarjeta">Tarjeta</option>
                     <option value="transferencia">Transferencia</option>
                     <option value="mixto">Mixto</option>
+                </select>
+            </div>
+
+            <div id="bank-field" style="display:none">
+                <label class="block text-sm font-medium text-gray-700">Cuenta Bancaria</label>
+                <select name="bank_account_id" class="form-select w-full mt-1">
+                    <option value="">-- Seleccionar --</option>
+                    @foreach($bankAccounts as $acc)
+                        <option value="{{ $acc->id }}">{{ $acc->bank }} - {{ $acc->account }}</option>
+                    @endforeach
                 </select>
             </div>
 
@@ -335,12 +345,19 @@
             }
         }
 
+        function toggleBank() {
+            const field = document.getElementById('bank-field');
+            const method = document.getElementById('payment_method').value;
+            field.style.display = method === 'transferencia' ? '' : 'none';
+        }
+
 
         document.querySelectorAll('input[name="service_ids[]"], select[name="vehicle_type_id"]').forEach(el => {
             el.addEventListener('change', updateTotal);
         });
 
         updateTotal();
+        toggleBank();
 
         function ticketForm() {
             return {

--- a/resources/views/tickets/partials/canceled-table.blade.php
+++ b/resources/views/tickets/partials/canceled-table.blade.php
@@ -6,6 +6,7 @@
                 <th class="border px-4 py-2">Facturaciones</th>
                 <th class="border px-4 py-2">Descuento</th>
                 <th class="border px-4 py-2">Total</th>
+                <th class="border px-4 py-2">Cuenta</th>
                 <th class="border px-4 py-2">Fecha</th>
             </tr>
         </thead>
@@ -20,6 +21,9 @@
                     </td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->discount_total, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->total_amount, 2) }}</td>
+                    <td class="px-4 py-2">
+                        {{ optional($ticket->bankAccount)->bank ? $ticket->bankAccount->bank.' - '.$ticket->bankAccount->account : '' }}
+                    </td>
                     <td class="px-4 py-2">{{ $ticket->created_at->format('d/m/Y H:i') }}</td>
                 </tr>
             @endforeach

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -6,6 +6,7 @@
                 <th class="border px-4 py-2">Facturaciones</th>
                 <th class="border px-4 py-2">Descuento</th>
                 <th class="border px-4 py-2">Total</th>
+                <th class="border px-4 py-2">Cuenta</th>
                 <th class="border px-4 py-2">Fecha</th>
             </tr>
         </thead>
@@ -20,6 +21,9 @@
                     </td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->discount_total, 2) }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->total_amount, 2) }}</td>
+                    <td class="px-4 py-2">
+                        {{ optional($ticket->bankAccount)->bank ? $ticket->bankAccount->bank.' - '.$ticket->bankAccount->account : '' }}
+                    </td>
                     <td class="px-4 py-2">{{ $ticket->created_at->format('d/m/Y H:i') }}</td>
                 </tr>
             @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::put('discounts/{discount}/activate', [\App\Http\Controllers\DiscountController::class, 'activate'])->name('discounts.activate');
     Route::put('discounts/{discount}/deactivate', [\App\Http\Controllers\DiscountController::class, 'deactivate'])->name('discounts.deactivate');
     Route::resource('discounts', \App\Http\Controllers\DiscountController::class);
+    Route::resource('bank-accounts', \App\Http\Controllers\BankAccountController::class);
 });
 Route::middleware(['auth', 'role:admin,cajero'])->group(function () {
     Route::resource('products', ProductController::class);


### PR DESCRIPTION
## Summary
- create `BankAccount` model, migration and seeder
- link tickets with bank accounts via migration and model relation
- add CRUD controller and views for bank accounts
- show/select bank accounts when paying by transfer
- display chosen account in ticket tables
- register new routes

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_684e4756f8f4832a8dc3bd3703b4ade2