### PR TITLE
Add cancel reason & UI tweaks

### DIFF
--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -14,7 +14,8 @@ class Ticket extends Model
         'customer_name', 'customer_cedula',
         'total_amount', 'paid_amount', 'change', 'discount_total',
         'payment_method', 'bank_account_id',
-        'washer_pending_amount', 'canceled', 'pending', 'paid_at'
+        'washer_pending_amount', 'canceled', 'cancel_reason',
+        'pending', 'paid_at'
     ];
 
     protected $casts = [

--- a/database/migrations/2025_06_17_002716_add_cancel_reason_to_tickets_table.php
+++ b/database/migrations/2025_06_17_002716_add_cancel_reason_to_tickets_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            if (!Schema::hasColumn('tickets', 'cancel_reason')) {
+                $table->string('cancel_reason')->nullable()->after('canceled');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            if (Schema::hasColumn('tickets', 'cancel_reason')) {
+                $table->dropColumn('cancel_reason');
+            }
+        });
+    }
+};

--- a/resources/views/tickets/canceled.blade.php
+++ b/resources/views/tickets/canceled.blade.php
@@ -5,7 +5,7 @@
         </h2>
     </x-slot>
 
-    <div x-data="filterTable('{{ route('tickets.canceled') }}')" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+    <div x-data="filterTable('{{ route('tickets.canceled') }}', {selected: null})" x-on:click.away="selected = null" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
         @if (session('success'))
             <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
@@ -23,6 +23,9 @@
                 </div>
             </form>
             <a href="{{ route('tickets.index') }}" class="text-blue-600 hover:underline">&laquo; Volver a activos</a>
+            <button x-show="selected" x-on:click="$dispatch('open-modal', 'view-' + selected)" class="text-gray-600" title="Ver">
+                <i class="fa-solid fa-eye fa-lg"></i>
+            </button>
         </div>
 
         <div x-html="tableHtml"></div>

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -140,7 +140,7 @@
             </div>
 
             <!-- Botón y Resumen -->
-            <div class="flex items-center gap-6 mt-4 fixed bottom-0 inset-x-0 mx-auto max-w-4xl bg-white p-4 shadow z-10 sm:px-6 lg:px-8">
+            <div class="flex items-center gap-6 mt-4 sticky bottom-0 bg-white p-4 shadow z-10 sm:px-6 lg:px-8">
                 <div class="flex-1 space-x-4">
                     <span>Descuento: RD$ <span id="discount_total">0.00</span></span>
                     <span>Total: RD$ <span id="total_amount">0.00</span></span>

--- a/resources/views/tickets/partials/canceled-table.blade.php
+++ b/resources/views/tickets/partials/canceled-table.blade.php
@@ -21,8 +21,8 @@
                         })->implode(', ') }}
                     </td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->discount_total, 2) }}</td>
-                    <td class="px-4 py-2">{{ $ticket->cancel_reason }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->total_amount, 2) }}</td>
+                    <td class="px-4 py-2">{{ $ticket->cancel_reason }}</td>
                     <td class="px-4 py-2">
                         {{ optional($ticket->bankAccount)->bank ? $ticket->bankAccount->bank.' - '.$ticket->bankAccount->account : '' }}
                     </td>

--- a/resources/views/tickets/partials/canceled-table.blade.php
+++ b/resources/views/tickets/partials/canceled-table.blade.php
@@ -6,13 +6,14 @@
                 <th class="border px-4 py-2">Facturaciones</th>
                 <th class="border px-4 py-2">Descuento</th>
                 <th class="border px-4 py-2">Total</th>
+                <th class="border px-4 py-2">Concepto</th>
                 <th class="border px-4 py-2">Cuenta</th>
                 <th class="border px-4 py-2">Fecha</th>
             </tr>
         </thead>
         <tbody>
             @foreach ($tickets as $ticket)
-                <tr class="border-t">
+                <tr class="border-t cursor-pointer" x-on:click="selected === {{ $ticket->id }} ? selected = null : selected = {{ $ticket->id }}" :class="selected === {{ $ticket->id }} ? 'bg-blue-100' : ''">
                     <td class="px-4 py-2">{{ $ticket->customer_name }}</td>
                     <td class="px-4 py-2">
                         {{ $ticket->details->pluck('type')->unique()->map(fn($t) => match($t){
@@ -20,6 +21,7 @@
                         })->implode(', ') }}
                     </td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->discount_total, 2) }}</td>
+                    <td class="px-4 py-2">{{ $ticket->cancel_reason }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->total_amount, 2) }}</td>
                     <td class="px-4 py-2">
                         {{ optional($ticket->bankAccount)->bank ? $ticket->bankAccount->bank.' - '.$ticket->bankAccount->account : '' }}
@@ -33,3 +35,43 @@
 <div class="mt-4">
     {{ $tickets->withQueryString()->links() }}
 </div>
+@foreach ($tickets as $ticket)
+    <x-modal name="view-{{ $ticket->id }}" focusable>
+        <div class="p-6 space-y-4 text-sm">
+            <p><strong>Cliente:</strong> {{ $ticket->customer_name }}</p>
+            <p><strong>Fecha:</strong> {{ $ticket->created_at->format('d/m/Y H:i') }}</p>
+            @if($ticket->vehicle)
+                <p><strong>Placa:</strong> {{ $ticket->vehicle->plate }}</p>
+                <p><strong>Marca:</strong> {{ $ticket->vehicle->brand }}</p>
+                <p><strong>Modelo:</strong> {{ $ticket->vehicle->model }}</p>
+                <p><strong>Color:</strong> {{ $ticket->vehicle->color }}</p>
+                @if($ticket->vehicle->year)
+                    <p><strong>Año:</strong> {{ $ticket->vehicle->year }}</p>
+                @endif
+            @endif
+            @if($ticket->vehicleType)
+                <p><strong>Tipo de Vehículo:</strong> {{ $ticket->vehicleType->name }}</p>
+            @endif
+            <div>
+                <h3 class="font-semibold mb-1">Detalles</h3>
+                <ul class="list-disc ps-5 space-y-1">
+                    @foreach($ticket->details as $d)
+                        <li>
+                            {{ match($d->type){
+                                'service' => $d->service->name ?? 'Servicio',
+                                'product' => $d->product->name ?? 'Producto',
+                                'drink' => $d->drink->name ?? 'Trago'
+                            } }} x{{ $d->quantity }} - RD$ {{ number_format($d->unit_price,2) }}
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+            <p><strong>Descuento:</strong> RD$ {{ number_format($ticket->discount_total, 2) }}</p>
+            <p><strong>Total:</strong> RD$ {{ number_format($ticket->total_amount, 2) }}</p>
+            <p><strong>Concepto:</strong> {{ $ticket->cancel_reason }}</p>
+            <div class="mt-6 flex justify-end">
+                <x-secondary-button x-on:click="$dispatch('close')">Cerrar</x-secondary-button>
+            </div>
+        </div>
+    </x-modal>
+@endforeach

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -43,10 +43,14 @@
 </div>
     @foreach ($tickets as $ticket)
         <x-modal name="cancel-{{ $ticket->id }}" focusable>
-        <form method="POST" action="{{ route('tickets.cancel', $ticket) }}" class="p-6">
+        <form method="POST" action="{{ route('tickets.cancel', $ticket) }}" class="p-6 space-y-4">
             @csrf
             <h2 class="text-lg font-medium text-gray-900">¿Cancelar este ticket?</h2>
-            <div class="mt-6 flex justify-end">
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Concepto de cancelación</label>
+                <input type="text" name="cancel_reason" class="form-input w-full" required>
+            </div>
+            <div class="flex justify-end">
                 <x-secondary-button x-on:click="$dispatch('close')">Cancelar</x-secondary-button>
                 <x-danger-button class="ms-3">Confirmar</x-danger-button>
             </div>
@@ -98,6 +102,12 @@
                 <p><strong>Fecha:</strong> {{ $ticket->created_at->format('d/m/Y H:i') }}</p>
                 @if($ticket->vehicle)
                     <p><strong>Placa:</strong> {{ $ticket->vehicle->plate }}</p>
+                    <p><strong>Marca:</strong> {{ $ticket->vehicle->brand }}</p>
+                    <p><strong>Modelo:</strong> {{ $ticket->vehicle->model }}</p>
+                    <p><strong>Color:</strong> {{ $ticket->vehicle->color }}</p>
+                    @if($ticket->vehicle->year)
+                        <p><strong>Año:</strong> {{ $ticket->vehicle->year }}</p>
+                    @endif
                 @endif
                 @if($ticket->vehicleType)
                     <p><strong>Tipo de Vehículo:</strong> {{ $ticket->vehicleType->name }}</p>


### PR DESCRIPTION
## Summary
- add cancel reason to tickets table and model
- require reason when canceling a ticket and display it in views
- enable viewing details for canceled tickets
- include full vehicle info in ticket detail modals
- adjust ticket totals panel to use sticky positioning

## Testing
- `php artisan test`
- `php artisan migrate --pretend` *(fails: Cancelled prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6850ee0e02f0832a84ff3f5fd5f4c0a0