### PR TITLE
Implement washer payment time and ticket references

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -563,6 +563,10 @@ class TicketController extends Controller
             return redirect()->route('tickets.index');
         }
 
+        if ($ticket->created_at->lt(now()->subHours(6))) {
+            return back()->with('error', 'No se puede cancelar un ticket con más de 6 horas de creado.');
+        }
+
         $request->validate([
             'cancel_reason' => 'required|string|max:255',
         ]);

--- a/app/Http/Controllers/WasherController.php
+++ b/app/Http/Controllers/WasherController.php
@@ -113,6 +113,7 @@ class WasherController extends Controller
                 'description' => implode(' | ', array_filter($detailParts)),
                 'gain' => 100,
                 'payment' => null,
+                'ticket_id' => $t->id,
             ];
         }
         foreach ($payments as $p) {
@@ -122,9 +123,10 @@ class WasherController extends Controller
                 'description' => 'Pago',
                 'gain' => null,
                 'payment' => $p->amount_paid,
+                'ticket_id' => null,
             ];
         }
-        usort($events, fn($a, $b) => $b['date']->timestamp <=> $a['date']->timestamp);
+        usort($events, fn($a, $b) => $a['date']->timestamp <=> $b['date']->timestamp);
 
         if ($request->ajax()) {
             return view('washers.partials.ledger', ['events' => $events]);
@@ -145,7 +147,7 @@ class WasherController extends Controller
 
         WasherPayment::create([
             'washer_id' => $washer->id,
-            'payment_date' => now()->toDateString(),
+            'payment_date' => now(),
             'total_washes' => intval($washer->pending_amount / 100),
             'amount_paid' => $washer->pending_amount,
         ]);
@@ -162,7 +164,7 @@ class WasherController extends Controller
         foreach ($washers as $washer) {
             WasherPayment::create([
                 'washer_id' => $washer->id,
-                'payment_date' => now()->toDateString(),
+                'payment_date' => now(),
                 'total_washes' => intval($washer->pending_amount / 100),
                 'amount_paid' => $washer->pending_amount,
             ]);

--- a/app/Models/WasherPayment.php
+++ b/app/Models/WasherPayment.php
@@ -12,6 +12,10 @@ class WasherPayment extends Model
         'washer_id', 'payment_date', 'total_washes', 'amount_paid', 'observations'
     ];
 
+    protected $casts = [
+        'payment_date' => 'datetime',
+    ];
+
     public function washer()
     {
         return $this->belongsTo(Washer::class);

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "doctrine/dbal": "^3.9",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf129d58fa9a70571645e78a68230150",
+    "content-hash": "d92084d25ad70f46c0b14918459a00b4",
     "packages": [
         {
             "name": "brick/math",
@@ -369,6 +369,349 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/1ca8f21980e770095a31456042471a57bc4c68fb",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.4 || ^6",
+                "symfony/var-exporter": "^4.4 || ^5.4 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/cache/issues",
+                "source": "https://github.com/doctrine/cache/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-20T20:07:39+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "3.9.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "4a4e2eed3134036ee36a147ee0dac037dfa17868"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/4a4e2eed3134036ee36a147ee0dac037dfa17868",
+                "reference": "4a4e2eed3134036ee36a147ee0dac037dfa17868",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/deprecations": "^0.5.3|^1",
+                "doctrine/event-manager": "^1|^2",
+                "php": "^7.4 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "13.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.1",
+                "phpstan/phpstan": "2.1.17",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "9.6.23",
+                "slevomat/coding-standard": "8.16.2",
+                "squizlabs/php_codesniffer": "3.13.1",
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/console": "^4.4|^5.4|^6.0|^7.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/3.9.5"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-15T22:40:05+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+            },
+            "time": "2025-04-07T20:06:18+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "b680156fa328f1dfd874fd48c7026c41570b9c6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/b680156fa328f1dfd874fd48c7026c41570b9c6e",
+                "reference": "b680156fa328f1dfd874fd48c7026c41570b9c6e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.8.8",
+                "phpunit/phpunit": "^10.5",
+                "vimeo/psalm": "^5.24"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-22T20:47:39+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -3057,6 +3400,55 @@
                 }
             ],
             "time": "2024-07-20T21:41:07+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/clock",

--- a/database/migrations/2025_06_17_145758_update_washer_payments_payment_date_column.php
+++ b/database/migrations/2025_06_17_145758_update_washer_payments_payment_date_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('washer_payments', function (Blueprint $table) {
+            $table->timestamp('payment_date')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('washer_payments', function (Blueprint $table) {
+            $table->date('payment_date')->change();
+        });
+    }
+};

--- a/database/migrations/2025_06_17_145758_update_washer_payments_payment_date_column.php
+++ b/database/migrations/2025_06_17_145758_update_washer_payments_payment_date_column.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -12,7 +13,17 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('washer_payments', function (Blueprint $table) {
-            $table->timestamp('payment_date')->change();
+            if (DB::getDriverName() === 'sqlite') {
+                $table->dropColumn('payment_date');
+            }
+        });
+
+        Schema::table('washer_payments', function (Blueprint $table) {
+            if (DB::getDriverName() === 'sqlite') {
+                $table->timestamp('payment_date')->nullable();
+            } else {
+                $table->timestamp('payment_date')->change();
+            }
         });
     }
 
@@ -22,7 +33,17 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('washer_payments', function (Blueprint $table) {
-            $table->date('payment_date')->change();
+            if (DB::getDriverName() === 'sqlite') {
+                $table->dropColumn('payment_date');
+            }
+        });
+
+        Schema::table('washer_payments', function (Blueprint $table) {
+            if (DB::getDriverName() === 'sqlite') {
+                $table->date('payment_date')->nullable();
+            } else {
+                $table->date('payment_date')->change();
+            }
         });
     }
 };

--- a/database/seeders/WasherPaymentSeeder.php
+++ b/database/seeders/WasherPaymentSeeder.php
@@ -20,7 +20,7 @@ class WasherPaymentSeeder extends Seeder
         // Pay washer1 for one wash two days ago (today payment)
         WasherPayment::create([
             'washer_id' => $washer1->id,
-            'payment_date' => $now->toDateString(),
+            'payment_date' => $now->toDateTimeString(),
             'total_washes' => 1,
             'amount_paid' => 100,
             'observations' => 'Pago de ejemplo',
@@ -30,7 +30,7 @@ class WasherPaymentSeeder extends Seeder
         // Pay washer2 for wash today
         WasherPayment::create([
             'washer_id' => $washer2->id,
-            'payment_date' => $now->toDateString(),
+            'payment_date' => $now->toDateTimeString(),
             'total_washes' => 1,
             'amount_paid' => 100,
             'observations' => 'Pago de ejemplo',

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -24,6 +24,16 @@ Alpine.data('filterTable', (url, extra = {}) => ({
     },
     init() {
         this.fetchTable();
+    },
+    openCancelModal() {
+        if (!this.selectedCreated) return;
+        const created = new Date(this.selectedCreated);
+        const diffHours = (Date.now() - created.getTime()) / 3600000;
+        if (diffHours > 6) {
+            this.$dispatch('open-modal', 'cancel-error');
+        } else {
+            this.$dispatch('open-modal', 'cancel-' + this.selected);
+        }
     }
 }));
 

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -1,13 +1,13 @@
 <div class="space-y-4">
-    <div class="grid md:grid-cols-2 gap-4">
-        <div class="bg-white p-4 shadow sm:rounded-lg flex flex-col items-center justify-center">
+    <div class="bg-white p-4 shadow sm:rounded-lg flex justify-around items-center">
+        <div class="text-center">
             <p class="text-lg">Total facturado</p>
-            <p class="text-2xl font-bold">RD$ {{ number_format($totalFacturado, 2) }}</p>
+            <p class="text-3xl font-bold">RD$ {{ number_format($totalFacturado, 2) }}</p>
         </div>
         @if(Auth::user()->role === 'admin')
-        <div class="bg-white p-4 shadow sm:rounded-lg flex flex-col items-center justify-center">
+        <div class="text-center">
             <p class="text-lg">Beneficio bruto</p>
-            <p class="text-2xl font-bold">RD$ {{ number_format($grossProfit, 2) }}</p>
+            <p class="text-3xl font-bold">RD$ {{ number_format($grossProfit, 2) }}</p>
         </div>
         @endif
     </div>

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -1,5 +1,18 @@
 <div class="space-y-4">
     <div class="grid md:grid-cols-2 gap-4">
+        <div class="bg-white p-4 shadow sm:rounded-lg flex flex-col items-center justify-center">
+            <p class="text-lg">Total facturado</p>
+            <p class="text-2xl font-bold">RD$ {{ number_format($totalFacturado, 2) }}</p>
+        </div>
+        @if(Auth::user()->role === 'admin')
+        <div class="bg-white p-4 shadow sm:rounded-lg flex flex-col items-center justify-center">
+            <p class="text-lg">Beneficio bruto</p>
+            <p class="text-2xl font-bold">RD$ {{ number_format($grossProfit, 2) }}</p>
+        </div>
+        @endif
+    </div>
+
+    <div class="grid md:grid-cols-2 gap-4">
         <div class="bg-white p-4 shadow sm:rounded-lg">
             <h3 class="text-lg font-semibold mb-2">Cuentas por cobrar</h3>
             <p>Total: <strong>RD$ {{ number_format($accountsReceivable, 2) }}</strong></p>
@@ -32,7 +45,6 @@
         </div>
         <div class="bg-white p-4 shadow sm:rounded-lg">
             <h3 class="text-lg font-semibold mb-2">Resumen</h3>
-            <p>Total facturado: <strong>RD$ {{ number_format($totalFacturado, 2) }}</strong></p>
             <p>Efectivo: <strong>RD$ {{ number_format($cashTotal, 2) }}</strong></p>
             <p>Transferencias: <strong>RD$ {{ number_format($transferTotal, 2) }}</strong></p>
             <p>Caja chica: <strong>RD$ 3,200.00</strong></p>
@@ -42,7 +54,7 @@
             <p>Ventas de productos: RD$ {{ number_format($productTotal, 2) }}</p>
             <p>Ventas de tragos: RD$ {{ number_format($drinkTotal, 2) }}</p>
             @if(Auth::user()->role === 'admin')
-                <p>Beneficio bruto: RD$ {{ number_format($grossProfit, 2) }}</p>
+                <!-- Beneficio bruto se muestra en la sección superior -->
             @endif
         </div>
     </div>

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -5,10 +5,13 @@
         </h2>
     </x-slot>
 
-    <div x-data="filterTable('{{ route('tickets.index') }}', {selected: null, selectedPending: false, selectedNoWasher: false, pending: {{ $filters['pending'] ?? 'null' }}})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+    <div x-data="filterTable('{{ route('tickets.index') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null, pending: {{ $filters['pending'] ?? 'null' }}})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
         @if (session('success'))
             <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
+        @endif
+        @if (session('error'))
+            <div class="mb-4 font-medium text-sm text-red-600">{{ session('error') }}</div>
         @endif
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
@@ -27,7 +30,7 @@
             <button type="button" class="px-4 py-2 bg-gray-200 rounded" @click="pending = null; fetchTable()">Todos</button>
             <a href="{{ route('tickets.create') }}" class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600">Nuevo Ticket</a>
             <a href="{{ route('tickets.canceled') }}" class="text-blue-600 hover:underline">Ver cancelados</a>
-            <button x-show="selected" x-on:click="$dispatch('open-modal', 'cancel-' + selected)" class="text-red-600" title="Cancelar">
+            <button x-show="selected" x-on:click="openCancelModal()" class="text-red-600" title="Cancelar">
                 <i class="fa-solid fa-xmark fa-lg"></i>
             </button>
             <button x-show="selected" x-on:click="$dispatch('open-modal', 'view-' + selected)" class="text-gray-600" title="Ver">
@@ -39,5 +42,14 @@
         </div>
 
         <div x-html="tableHtml"></div>
+        <x-modal name="cancel-error" focusable>
+            <div class="p-6">
+                <h2 class="text-lg font-medium text-gray-900 mb-4">No se puede cancelar</h2>
+                <p>Este ticket tiene más de 6 horas de creado.</p>
+                <div class="mt-6 flex justify-end">
+                    <x-secondary-button x-on:click="$dispatch('close')">Cerrar</x-secondary-button>
+                </div>
+            </div>
+        </x-modal>
     </div>
 </x-app-layout>

--- a/resources/views/tickets/partials/canceled-table.blade.php
+++ b/resources/views/tickets/partials/canceled-table.blade.php
@@ -2,6 +2,7 @@
     <table class="min-w-full table-auto border">
         <thead class="bg-gray-200">
             <tr>
+                <th class="border px-4 py-2">ID</th>
                 <th class="border px-4 py-2">Cliente</th>
                 <th class="border px-4 py-2">Facturaciones</th>
                 <th class="border px-4 py-2">Descuento</th>
@@ -14,6 +15,7 @@
         <tbody>
             @foreach ($tickets as $ticket)
                 <tr class="border-t cursor-pointer" x-on:click="selected === {{ $ticket->id }} ? selected = null : selected = {{ $ticket->id }}" :class="selected === {{ $ticket->id }} ? 'bg-blue-100' : ''">
+                    <td class="px-4 py-2">{{ $ticket->id }}</td>
                     <td class="px-4 py-2">{{ $ticket->customer_name }}</td>
                     <td class="px-4 py-2">
                         {{ $ticket->details->pluck('type')->unique()->map(fn($t) => match($t){

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -2,6 +2,7 @@
     <table class="min-w-full table-auto border">
         <thead class="bg-gray-200">
             <tr>
+                <th class="border px-4 py-2">ID</th>
                 <th class="border px-4 py-2">Cliente</th>
                 <th class="border px-4 py-2">Facturaciones</th>
                 <th class="border px-4 py-2">Descuento</th>
@@ -15,12 +16,13 @@
                 <tr class="border-t cursor-pointer {{ $ticket->pending ? 'bg-red-100' : (!$ticket->washer_id && $ticket->details->where('type','service')->count() ? 'bg-orange-100' : '') }}"
                     x-on:click="
                         if (selected === {{ $ticket->id }}) {
-                            selected = null; selectedPending = false; selectedNoWasher = false;
+                            selected = null; selectedPending = false; selectedNoWasher = false; selectedCreated = null;
                         } else {
-                            selected = {{ $ticket->id }}; selectedPending = {{ $ticket->pending ? 'true' : 'false' }}; selectedNoWasher = {{ (!$ticket->washer_id && $ticket->details->where('type','service')->count()) ? 'true' : 'false' }};
+                            selected = {{ $ticket->id }}; selectedPending = {{ $ticket->pending ? 'true' : 'false' }}; selectedNoWasher = {{ (!$ticket->washer_id && $ticket->details->where('type','service')->count()) ? 'true' : 'false' }}; selectedCreated = '{{ $ticket->created_at }}';
                         }
                     "
                     :class="selected === {{ $ticket->id }} ? (selectedPending ? 'bg-red-300' : (selectedNoWasher ? 'bg-orange-300' : 'bg-blue-100')) : ''">
+                    <td class="px-4 py-2">{{ $ticket->id }}</td>
                     <td class="px-4 py-2">{{ $ticket->customer_name }}</td>
                     <td class="px-4 py-2">
                         {{ $ticket->details->pluck('type')->unique()->map(fn($t) => match($t){

--- a/resources/views/tickets/pending.blade.php
+++ b/resources/views/tickets/pending.blade.php
@@ -5,10 +5,13 @@
         </h2>
     </x-slot>
 
-    <div x-data="filterTable('{{ route('tickets.pending') }}', {selected: null, selectedPending: false, selectedNoWasher: false})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+    <div x-data="filterTable('{{ route('tickets.pending') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
         @if (session('success'))
             <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
+        @endif
+        @if (session('error'))
+            <div class="mb-4 font-medium text-sm text-red-600">{{ session('error') }}</div>
         @endif
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
@@ -25,7 +28,7 @@
             <a href="{{ route('tickets.index') }}" class="text-blue-600 hover:underline">&laquo; Volver a tickets</a>
         </div>
         <div class="mb-4 flex gap-4">
-            <button x-show="selected" x-on:click="$dispatch('open-modal', 'cancel-' + selected)" class="text-red-600" title="Cancelar">
+            <button x-show="selected" x-on:click="openCancelModal()" class="text-red-600" title="Cancelar">
                 <i class="fa-solid fa-xmark fa-lg"></i>
             </button>
             <button x-show="selected" x-on:click="$dispatch('open-modal', 'view-' + selected)" class="text-gray-600" title="Ver">
@@ -37,5 +40,14 @@
         </div>
 
         <div x-html="tableHtml"></div>
+        <x-modal name="cancel-error" focusable>
+            <div class="p-6">
+                <h2 class="text-lg font-medium text-gray-900 mb-4">No se puede cancelar</h2>
+                <p>Este ticket tiene más de 6 horas de creado.</p>
+                <div class="mt-6 flex justify-end">
+                    <x-secondary-button x-on:click="$dispatch('close')">Cerrar</x-secondary-button>
+                </div>
+            </div>
+        </x-modal>
     </div>
 </x-app-layout>

--- a/resources/views/washers/partials/ledger.blade.php
+++ b/resources/views/washers/partials/ledger.blade.php
@@ -3,6 +3,7 @@
         <thead class="bg-gray-200">
             <tr>
                 <th class="px-4 py-2">Fecha</th>
+                <th class="px-4 py-2">Ticket ID</th>
                 <th class="px-4 py-2">Cliente</th>
                 <th class="px-4 py-2">Detalle</th>
                 <th class="px-4 py-2">Ganancia</th>
@@ -12,7 +13,8 @@
         <tbody>
             @foreach($events as $e)
                 <tr class="border-b">
-                    <td class="px-4 py-2">{{ \Carbon\Carbon::parse($e['date'])->format('d/m/Y') }}</td>
+                    <td class="px-4 py-2">{{ \Carbon\Carbon::parse($e['date'])->format('d/m/Y H:i') }}</td>
+                    <td class="px-4 py-2">{{ $e['ticket_id'] ?? '' }}</td>
                     <td class="px-4 py-2">{{ $e['customer'] ?? '' }}</td>
                     <td class="px-4 py-2">{{ $e['description'] }}</td>
                     <td class="px-4 py-2">


### PR DESCRIPTION
## Summary
- show total facturado and beneficio bruto in a dedicated dashboard row
- reference ticket id in washer ledger and ticket tables
- sort washer ledger chronologically
- track payment time with timestamp migration
- block ticket cancellation after six hours using modal feedback

## Testing
- `npm run build`
- `php artisan test` *(fails: Changing columns for table "washer_payments" requires Doctrine DBAL)*

------
https://chatgpt.com/codex/tasks/task_e_6851b991cf04832a9a9d24015a19e353