### PR TITLE
Improve table UX and reorganize navigation

### DIFF
--- a/app/Http/Controllers/InventoryMovementController.php
+++ b/app/Http/Controllers/InventoryMovementController.php
@@ -31,7 +31,7 @@ class InventoryMovementController extends Controller
             });
         }
 
-        $movements = $query->latest()->paginate(20);
+        $movements = $query->latest()->get();
 
         if ($request->ajax()) {
             return view('inventory.partials.table', [

--- a/app/Http/Controllers/PettyCashExpenseController.php
+++ b/app/Http/Controllers/PettyCashExpenseController.php
@@ -28,7 +28,7 @@ class PettyCashExpenseController extends Controller
             $query->whereDate('created_at', '<=', $filters['end']);
         }
 
-        $expenses = $query->latest()->paginate(20);
+        $expenses = $query->latest()->get();
 
         $todayTotal = PettyCashExpense::whereDate('created_at', now()->toDateString())->sum('amount');
         $remaining = max(0, 3200 - $todayTotal);

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -195,13 +195,18 @@ class TicketController extends Controller
     {
         $pending = $request->input('ticket_action') === 'pending';
 
+        $serviceIds = $request->input('service_ids', []);
+        $hasWash = Service::whereIn('id', $serviceIds)
+            ->where('name', 'like', 'Lavado%')
+            ->exists();
+
         $rules = [
             'customer_name' => ['required', 'regex:/^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/', 'max:255'],
-            'vehicle_type_id' => 'nullable|exists:vehicle_types,id',
-            'plate' => ['required_with:service_ids', 'alpha_num', 'max:20'],
-            'brand' => ['required_with:service_ids', 'regex:/^[A-Za-z0-9\s]+$/', 'max:50'],
-            'model' => ['required_with:service_ids', 'regex:/^[A-Za-z0-9\s]+$/', 'max:50'],
-            'color' => ['required_with:service_ids', 'regex:/^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/', 'max:50'],
+            'vehicle_type_id' => [$hasWash ? 'required' : 'nullable', 'exists:vehicle_types,id'],
+            'plate' => [$hasWash ? 'required' : 'nullable', 'alpha_num', 'max:20'],
+            'brand' => [$hasWash ? 'required' : 'nullable', 'regex:/^[A-Za-z0-9\s]+$/', 'max:50'],
+            'model' => [$hasWash ? 'required' : 'nullable', 'regex:/^[A-Za-z0-9\s]+$/', 'max:50'],
+            'color' => [$hasWash ? 'required' : 'nullable', 'regex:/^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/', 'max:50'],
             'year' => 'nullable|integer|between:1890,' . date('Y'),
             'washer_id' => 'nullable|exists:washers,id',
             'service_ids' => 'nullable|array',
@@ -224,14 +229,15 @@ class TicketController extends Controller
         $request->validate($rules, [
             'customer_name.required' => 'El nombre del cliente es obligatorio.',
             'customer_name.max' => 'El nombre del cliente es demasiado largo.',
+            'vehicle_type_id.required' => 'El tipo de vehículo es obligatorio.',
             'vehicle_type_id.exists' => 'El tipo de vehículo seleccionado no es válido.',
-            'plate.required_with' => 'La placa es obligatoria.',
+            'plate.required' => 'La placa es obligatoria.',
             'plate.alpha_num' => 'La placa solo puede contener letras y numeros.',
-            'brand.required_with' => 'La marca es obligatoria.',
+            'brand.required' => 'La marca es obligatoria.',
             'brand.regex' => 'La marca solo puede contener letras y numeros.',
-            'model.required_with' => 'El modelo es obligatorio.',
+            'model.required' => 'El modelo es obligatorio.',
             'model.regex' => 'El modelo solo puede contener letras y numeros.',
-            'color.required_with' => 'El color es obligatorio.',
+            'color.required' => 'El color es obligatorio.',
             'color.regex' => 'El color solo puede contener letras.',
             'customer_name.regex' => 'El nombre solo puede contener letras.',
             'year.between' => 'El año debe estar entre 1890 y '.date('Y').'.',

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -39,7 +39,7 @@ class TicketController extends Controller
             $query->whereDate('created_at', '<=', $request->end);
         }
 
-        $tickets = $query->latest()->paginate(20);
+        $tickets = $query->latest()->get();
 
         $bankAccounts = BankAccount::all();
         $washers = Washer::where('active', true)->get();
@@ -72,7 +72,7 @@ class TicketController extends Controller
             $query->whereDate('created_at', '<=', $request->end);
         }
 
-        $tickets = $query->latest()->paginate(20);
+        $tickets = $query->latest()->get();
 
         if ($request->ajax()) {
             return view('tickets.partials.canceled-table', [
@@ -100,7 +100,7 @@ class TicketController extends Controller
             $query->whereDate('created_at', '<=', $request->end);
         }
 
-        $tickets = $query->latest()->paginate(20);
+        $tickets = $query->latest()->get();
         $bankAccounts = BankAccount::all();
         $washers = Washer::where('active', true)->get();
 

--- a/resources/views/bank_accounts/index.blade.php
+++ b/resources/views/bank_accounts/index.blade.php
@@ -19,7 +19,7 @@
                 </a>
             </div>
 
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
                 <table class="min-w-full table-auto border">
                     <thead class="bg-gray-200">
                         <tr>

--- a/resources/views/dashboard/partials/movements-table.blade.php
+++ b/resources/views/dashboard/partials/movements-table.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white shadow-sm sm:rounded-lg overflow-hidden">
+<div class="bg-white shadow-sm sm:rounded-lg overflow-hidden max-h-96 overflow-y-auto">
     <table class="min-w-full table-auto border">
         <thead class="bg-gray-200">
             <tr>

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -13,7 +13,7 @@
     </div>
 
     <div class="grid md:grid-cols-2 gap-4">
-        <div class="bg-white p-4 shadow sm:rounded-lg">
+        <div class="bg-white p-4 shadow sm:rounded-lg max-h-96 overflow-y-auto">
             <h3 class="text-lg font-semibold mb-2">Cuentas por cobrar</h3>
             <p>Total: <strong>RD$ {{ number_format($accountsReceivable, 2) }}</strong></p>
             <table class="min-w-full mt-2 table-auto text-sm border">

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -14,7 +14,7 @@
             <a href="{{ route('discounts.create') }}" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Nuevo Descuento</a>
         </div>
 
-        <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+        <div class="bg-white shadow overflow-hidden sm:rounded-lg max-h-96 overflow-y-auto">
             <table class="min-w-full divide-y divide-gray-200">
                 <thead class="bg-gray-50">
                     <tr>

--- a/resources/views/drinks/partials/table.blade.php
+++ b/resources/views/drinks/partials/table.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
     <table class="min-w-full table-auto border">
         <thead class="bg-gray-200">
             <tr>

--- a/resources/views/inventory/partials/table.blade.php
+++ b/resources/views/inventory/partials/table.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
     <table class="min-w-full table-auto border">
         <thead class="bg-gray-200">
             <tr>
@@ -23,7 +23,4 @@
             @endforeach
         </tbody>
     </table>
-</div>
-<div class="mt-4">
-    {{ $movements->withQueryString()->links() }}
 </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -13,9 +13,15 @@
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
+                        </svg>
                         {{ __('Panel de Control') }}
                     </x-nav-link>
                     <x-nav-link :href="route('inventory.index')" :active="request()->routeIs('inventory.*')">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.375 4.5h17.25M4.5 7.5v12.75A2.25 2.25 0 0 0 6.75 22.5h10.5a2.25 2.25 0 0 0 2.25-2.25V7.5m-13.5 0h13.5" />
+                        </svg>
                         {{ __('Inventario') }}
                     </x-nav-link>
                 </div>
@@ -71,9 +77,15 @@
     <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
+                <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
+                </svg>
                 {{ __('Panel de Control') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('inventory.index')" :active="request()->routeIs('inventory.*')">
+                <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.375 4.5h17.25M4.5 7.5v12.75A2.25 2.25 0 0 0 6.75 22.5h10.5a2.25 2.25 0 0 0 2.25-2.25V7.5m-13.5 0h13.5" />
+                </svg>
                 {{ __('Inventario') }}
             </x-responsive-nav-link>
         </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,9 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Panel de Control') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('inventory.index')" :active="request()->routeIs('inventory.*')">
+                        {{ __('Inventario') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -69,6 +72,9 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Panel de Control') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('inventory.index')" :active="request()->routeIs('inventory.*')">
+                {{ __('Inventario') }}
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -2,46 +2,107 @@
     <div class="p-4">
         <nav class="space-y-2">
             <a href="{{ route('dashboard') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('dashboard') ? 'bg-gray-200' : '' }}">
+                <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
+                </svg>
                 Panel de Control
             </a>
             <a href="{{ route('petty-cash.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('petty-cash.*') ? 'bg-gray-200' : '' }}">
+                <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4.5a2.25 2.25 0 0 0-4.5 0V6M9 16.5v3m0 0a2.25 2.25 0 1 0 4.5 0v-3m-4.5 0H3.75A2.25 2.25 0 0 1 1.5 14.25V9.75A2.25 2.25 0 0 1 3.75 7.5H20.25A2.25 2.25 0 0 1 22.5 9.75v4.5a2.25 2.25 0 0 1-2.25 2.25H15" />
+                </svg>
                 Caja Chica
             </a>
             <a href="{{ route('washers.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('washers.*') ? 'bg-gray-200' : '' }}">
+                <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5V4H2v16h5m0 0v-2.5A2.5 2.5 0 0 1 9.5 15h5a2.5 2.5 0 0 1 2.5 2.5V20m-10 0h10" />
+                </svg>
                 Lavadores
             </a>
             <div x-data="{ open: {{ request()->routeIs('services.*','products.*','drinks.*') ? 'true' : 'false' }} }">
                 <button type="button" @click="open=!open" class="w-full text-left px-3 py-2 font-semibold rounded hover:bg-gray-100 {{ request()->routeIs('services.*','products.*','drinks.*') ? 'bg-gray-200' : '' }}">
-                    Servicios, Productos y Tragos
+                    <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18V3H3zm4.5 4.5h9m-9 4.5h9m-9 4.5h9" />
+                    </svg>
+                    Catálogo
                 </button>
                 <div x-show="open" x-cloak class="pl-6 space-y-1">
-                    <a href="{{ route('services.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('services.*') ? 'bg-gray-200' : '' }}">Servicios</a>
-                    <a href="{{ route('products.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('products.*') ? 'bg-gray-200' : '' }}">Productos</a>
-                    <a href="{{ route('drinks.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('drinks.*') ? 'bg-gray-200' : '' }}">Tragos</a>
+                    <a href="{{ route('services.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('services.*') ? 'bg-gray-200' : '' }}">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3l1.61 14.49a1.125 1.125 0 0 0 1.12.99h11.04a1.125 1.125 0 0 0 1.12-.99L20.25 3H3.75zm9 18a1.5 1.5 0 0 1-3 0" />
+                        </svg>
+                        Servicios
+                    </a>
+                    <a href="{{ route('products.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('products.*') ? 'bg-gray-200' : '' }}">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 3.75A1.5 1.5 0 0 0 6 5.25V21l6-3 6 3V5.25a1.5 1.5 0 0 0-1.5-1.5h-9z" />
+                        </svg>
+                        Productos
+                    </a>
+                    <a href="{{ route('drinks.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('drinks.*') ? 'bg-gray-200' : '' }}">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3h10.5M9 3v12a3 3 0 1 0 6 0V3" />
+                        </svg>
+                        Tragos
+                    </a>
                 </div>
             </div>
             <div x-data="{ open: {{ request()->routeIs('tickets.*') ? 'true' : 'false' }} }">
                 <button type="button" @click="open=!open" class="w-full text-left px-3 py-2 font-semibold rounded hover:bg-gray-100 {{ request()->routeIs('tickets.*') ? 'bg-gray-200' : '' }}">
+                    <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 9.75h15M5.25 6h13.5a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V6.75a.75.75 0 0 1 .75-.75z" />
+                    </svg>
                     Tickets
                 </button>
                 <div x-show="open" x-cloak class="pl-6 space-y-1">
-                    <a href="{{ route('tickets.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('tickets.index') ? 'bg-gray-200' : '' }}">Activos</a>
-                    <a href="{{ route('tickets.canceled') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('tickets.canceled') ? 'bg-gray-200' : '' }}">Cancelados</a>
+                    <a href="{{ route('tickets.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('tickets.index') ? 'bg-gray-200' : '' }}">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                        </svg>
+                        Activos
+                    </a>
+                    <a href="{{ route('tickets.canceled') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('tickets.canceled') ? 'bg-gray-200' : '' }}">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 6.75l10.5 10.5m0-10.5L6.75 17.25" />
+                        </svg>
+                        Cancelados
+                    </a>
                 </div>
             </div>
             @if(auth()->user()->role === 'admin')
             <div x-data="{ open: {{ request()->routeIs('discounts.*','users.*','bank-accounts.*') ? 'true' : 'false' }} }">
                 <button type="button" @click="open=!open" class="w-full text-left px-3 py-2 font-semibold rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*','users.*','bank-accounts.*') ? 'bg-gray-200' : '' }}">
+                    <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12a7.5 7.5 0 0 1 15 0 7.5 7.5 0 0 1-15 0z" />
+                    </svg>
                     Configuración
                 </button>
                 <div x-show="open" x-cloak class="pl-6 space-y-1">
-                    <a href="{{ route('discounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*') ? 'bg-gray-200' : '' }}">Descuentos</a>
-                    <a href="{{ route('bank-accounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('bank-accounts.*') ? 'bg-gray-200' : '' }}">Cuentas Bancarias</a>
-                    <a href="{{ route('users.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('users.*') ? 'bg-gray-200' : '' }}">Usuarios</a>
+                    <a href="{{ route('discounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*') ? 'bg-gray-200' : '' }}">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75v10.5M6.75 6.75v10.5m-1.5-9h14.5m-14.5 4.5h14.5" />
+                        </svg>
+                        Descuentos
+                    </a>
+                    <a href="{{ route('bank-accounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('bank-accounts.*') ? 'bg-gray-200' : '' }}">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l9.72-9.72a.75.75 0 0 1 1.06 0l9.72 9.72m-19.5 0h19.5M4.5 12v8.25a.75.75 0 0 0 .75.75h13.5a.75.75 0 0 0 .75-.75V12" />
+                        </svg>
+                        Cuentas Bancarias
+                    </a>
+                    <a href="{{ route('users.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('users.*') ? 'bg-gray-200' : '' }}">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-4.215A3 3 0 0 0 15.101 10.8L12 10.2l-3.101.6a3 3 0 0 0-3.494 1.985L4 17h5m6 0v2.25a3 3 0 1 1-6 0V17m6 0h-6" />
+                        </svg>
+                        Usuarios
+                    </a>
                 </div>
             </div>
             @endif
             <a href="{{ route('profile.edit') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('profile.*') ? 'bg-gray-200' : '' }}">
+                <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 7.5a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0zM4.5 20.25a8.25 8.25 0 0 1 15 0" />
+                </svg>
                 Perfil
             </a>
         </nav>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -4,26 +4,22 @@
             <a href="{{ route('dashboard') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('dashboard') ? 'bg-gray-200' : '' }}">
                 Panel de Control
             </a>
-            <a href="{{ route('services.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('services.*') ? 'bg-gray-200' : '' }}">
-                Servicios
-            </a>
-            <a href="{{ route('products.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('products.*') ? 'bg-gray-200' : '' }}">
-                Productos
-            </a>
-            <a href="{{ route('drinks.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('drinks.*') ? 'bg-gray-200' : '' }}">
-                Tragos
-            </a>
-            @if(auth()->user()->role === 'admin')
-                <a href="{{ route('discounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*') ? 'bg-gray-200' : '' }}">
-                    Descuentos
-                </a>
-            @endif
-            <a href="{{ route('inventory.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('inventory.*') ? 'bg-gray-200' : '' }}">
-                Inventario
+            <a href="{{ route('petty-cash.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('petty-cash.*') ? 'bg-gray-200' : '' }}">
+                Caja Chica
             </a>
             <a href="{{ route('washers.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('washers.*') ? 'bg-gray-200' : '' }}">
                 Lavadores
             </a>
+            <div x-data="{ open: {{ request()->routeIs('services.*','products.*','drinks.*') ? 'true' : 'false' }} }">
+                <button type="button" @click="open=!open" class="w-full text-left px-3 py-2 font-semibold rounded hover:bg-gray-100 {{ request()->routeIs('services.*','products.*','drinks.*') ? 'bg-gray-200' : '' }}">
+                    Servicios, Productos y Tragos
+                </button>
+                <div x-show="open" x-cloak class="pl-6 space-y-1">
+                    <a href="{{ route('services.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('services.*') ? 'bg-gray-200' : '' }}">Servicios</a>
+                    <a href="{{ route('products.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('products.*') ? 'bg-gray-200' : '' }}">Productos</a>
+                    <a href="{{ route('drinks.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('drinks.*') ? 'bg-gray-200' : '' }}">Tragos</a>
+                </div>
+            </div>
             <div x-data="{ open: {{ request()->routeIs('tickets.*') ? 'true' : 'false' }} }">
                 <button type="button" @click="open=!open" class="w-full text-left px-3 py-2 font-semibold rounded hover:bg-gray-100 {{ request()->routeIs('tickets.*') ? 'bg-gray-200' : '' }}">
                     Tickets
@@ -34,16 +30,17 @@
                 </div>
             </div>
             @if(auth()->user()->role === 'admin')
-                <a href="{{ route('users.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('users.*') ? 'bg-gray-200' : '' }}">
-                    Usuarios
-                </a>
-                <a href="{{ route('bank-accounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('bank-accounts.*') ? 'bg-gray-200' : '' }}">
-                    Cuentas Bancarias
-                </a>
+            <div x-data="{ open: {{ request()->routeIs('discounts.*','users.*','bank-accounts.*') ? 'true' : 'false' }} }">
+                <button type="button" @click="open=!open" class="w-full text-left px-3 py-2 font-semibold rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*','users.*','bank-accounts.*') ? 'bg-gray-200' : '' }}">
+                    Configuración
+                </button>
+                <div x-show="open" x-cloak class="pl-6 space-y-1">
+                    <a href="{{ route('discounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*') ? 'bg-gray-200' : '' }}">Descuentos</a>
+                    <a href="{{ route('bank-accounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('bank-accounts.*') ? 'bg-gray-200' : '' }}">Cuentas Bancarias</a>
+                    <a href="{{ route('users.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('users.*') ? 'bg-gray-200' : '' }}">Usuarios</a>
+                </div>
+            </div>
             @endif
-            <a href="{{ route('petty-cash.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('petty-cash.*') ? 'bg-gray-200' : '' }}">
-                Caja Chica
-            </a>
             <a href="{{ route('profile.edit') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('profile.*') ? 'bg-gray-200' : '' }}">
                 Perfil
             </a>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -27,19 +27,19 @@
                     Catálogo
                 </button>
                 <div x-show="open" x-cloak class="pl-6 space-y-1">
-                    <a href="{{ route('services.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('services.*') ? 'bg-gray-200' : '' }}">
+                    <a href="{{ route('services.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('services.*') ? 'border-b-2 border-gray-500' : '' }}">
                         <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3l1.61 14.49a1.125 1.125 0 0 0 1.12.99h11.04a1.125 1.125 0 0 0 1.12-.99L20.25 3H3.75zm9 18a1.5 1.5 0 0 1-3 0" />
                         </svg>
                         Servicios
                     </a>
-                    <a href="{{ route('products.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('products.*') ? 'bg-gray-200' : '' }}">
+                    <a href="{{ route('products.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('products.*') ? 'border-b-2 border-gray-500' : '' }}">
                         <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 3.75A1.5 1.5 0 0 0 6 5.25V21l6-3 6 3V5.25a1.5 1.5 0 0 0-1.5-1.5h-9z" />
                         </svg>
                         Productos
                     </a>
-                    <a href="{{ route('drinks.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('drinks.*') ? 'bg-gray-200' : '' }}">
+                    <a href="{{ route('drinks.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('drinks.*') ? 'border-b-2 border-gray-500' : '' }}">
                         <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3h10.5M9 3v12a3 3 0 1 0 6 0V3" />
                         </svg>
@@ -55,13 +55,13 @@
                     Tickets
                 </button>
                 <div x-show="open" x-cloak class="pl-6 space-y-1">
-                    <a href="{{ route('tickets.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('tickets.index') ? 'bg-gray-200' : '' }}">
+                    <a href="{{ route('tickets.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('tickets.index') ? 'border-b-2 border-gray-500' : '' }}">
                         <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
                         </svg>
                         Activos
                     </a>
-                    <a href="{{ route('tickets.canceled') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('tickets.canceled') ? 'bg-gray-200' : '' }}">
+                    <a href="{{ route('tickets.canceled') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('tickets.canceled') ? 'border-b-2 border-gray-500' : '' }}">
                         <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 6.75l10.5 10.5m0-10.5L6.75 17.25" />
                         </svg>
@@ -78,19 +78,19 @@
                     Configuración
                 </button>
                 <div x-show="open" x-cloak class="pl-6 space-y-1">
-                    <a href="{{ route('discounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*') ? 'bg-gray-200' : '' }}">
+                    <a href="{{ route('discounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*') ? 'border-b-2 border-gray-500' : '' }}">
                         <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75v10.5M6.75 6.75v10.5m-1.5-9h14.5m-14.5 4.5h14.5" />
                         </svg>
                         Descuentos
                     </a>
-                    <a href="{{ route('bank-accounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('bank-accounts.*') ? 'bg-gray-200' : '' }}">
+                    <a href="{{ route('bank-accounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('bank-accounts.*') ? 'border-b-2 border-gray-500' : '' }}">
                         <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l9.72-9.72a.75.75 0 0 1 1.06 0l9.72 9.72m-19.5 0h19.5M4.5 12v8.25a.75.75 0 0 0 .75.75h13.5a.75.75 0 0 0 .75-.75V12" />
                         </svg>
                         Cuentas Bancarias
                     </a>
-                    <a href="{{ route('users.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('users.*') ? 'bg-gray-200' : '' }}">
+                    <a href="{{ route('users.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('users.*') ? 'border-b-2 border-gray-500' : '' }}">
                         <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-4.215A3 3 0 0 0 15.101 10.8L12 10.2l-3.101.6a3 3 0 0 0-3.494 1.985L4 17h5m6 0v2.25a3 3 0 1 1-6 0V17m6 0h-6" />
                         </svg>

--- a/resources/views/petty_cash/partials/table.blade.php
+++ b/resources/views/petty_cash/partials/table.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
     <table class="min-w-full table-auto border">
         <thead class="bg-gray-200">
             <tr>
@@ -25,7 +25,4 @@
             @endforeach
         </tbody>
     </table>
-</div>
-<div class="mt-4">
-    {{ $expenses->withQueryString()->links() }}
 </div>

--- a/resources/views/products/partials/table.blade.php
+++ b/resources/views/products/partials/table.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
     <table class="min-w-full table-auto border">
         <thead class="bg-gray-200">
             <tr>

--- a/resources/views/services/index.blade.php
+++ b/resources/views/services/index.blade.php
@@ -22,7 +22,7 @@
             </div>
         @endif
 
-        <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+        <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
             <table class="min-w-full table-auto border">
                 <thead class="bg-gray-200">
                     <tr>

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -116,6 +116,7 @@
             <div>
                 <label class="block text-sm font-medium text-gray-700">Monto Pagado (RD$)</label>
                 <input type="number" name="paid_amount" id="paid_amount" step="0.01" class="form-input w-full mt-1" oninput="updateChange()">
+                <p id="paid_warning" class="text-sm text-red-600"></p>
             </div>
 
             <!-- Método de Pago -->
@@ -295,6 +296,12 @@
             const paid = paidField.value === '' ? null : parseFloat(paidField.value);
             const change = paid === null ? 0 : paid - total;
             document.getElementById('change_display').innerText = formatCurrency(change);
+            const warn = document.getElementById('paid_warning');
+            if (paid !== null && paid < total) {
+                warn.textContent = 'Monto insuficiente';
+            } else {
+                warn.textContent = '';
+            }
         }
 
         function addProductRow() {
@@ -384,9 +391,10 @@
             } else {
                 wash.style.display = 'none';
                 btn.textContent = 'Agregar Lavado';
-                wash.querySelectorAll('select, input[type=checkbox]').forEach(el => {
+                wash.querySelectorAll('select, input[type=checkbox], input[type=text], input[type=number]').forEach(el => {
                     if (el.tagName === 'SELECT') el.value = '';
                     if (el.type === 'checkbox') el.checked = false;
+                    if (el.type === 'text' || el.type === 'number') el.value = '';
                 });
                 updateTotal();
             }

--- a/resources/views/tickets/partials/canceled-table.blade.php
+++ b/resources/views/tickets/partials/canceled-table.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white shadow-sm sm:rounded-lg overflow-hidden">
+<div class="bg-white shadow-sm sm:rounded-lg overflow-hidden max-h-96 overflow-y-auto">
     <table class="min-w-full table-auto border">
         <thead class="bg-gray-200">
             <tr>
@@ -33,9 +33,6 @@
             @endforeach
         </tbody>
     </table>
-</div>
-<div class="mt-4">
-    {{ $tickets->withQueryString()->links() }}
 </div>
 @foreach ($tickets as $ticket)
     <x-modal name="view-{{ $ticket->id }}" focusable>

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white shadow-sm sm:rounded-lg overflow-hidden">
+<div class="bg-white shadow-sm sm:rounded-lg overflow-hidden max-h-96 overflow-y-auto">
     <table class="min-w-full table-auto border">
         <thead class="bg-gray-200">
             <tr>
@@ -39,9 +39,6 @@
             @endforeach
         </tbody>
     </table>
-</div>
-<div class="mt-4">
-    {{ $tickets->withQueryString()->links() }}
 </div>
     @foreach ($tickets as $ticket)
         <x-modal name="cancel-{{ $ticket->id }}" focusable>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -19,7 +19,7 @@
                 </a>
             </div>
 
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
                 <table class="min-w-full table-auto border">
                     <thead class="bg-gray-200">
                         <tr>

--- a/resources/views/washers/index.blade.php
+++ b/resources/views/washers/index.blade.php
@@ -24,7 +24,7 @@
                 </form>
             </div>
 
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
                 <table class="min-w-full table-auto border">
                     <thead class="bg-gray-200">
                         <tr>

--- a/resources/views/washers/show.blade.php
+++ b/resources/views/washers/show.blade.php
@@ -5,7 +5,7 @@
         </h2>
     </x-slot>
 
-    <div x-data="filterTable('{{ route('washers.show', $washer) }}')" class="py-4 max-w-4xl mx-auto sm:px-6 lg:px-8">
+    <div x-data="filterTable('{{ route('washers.show', $washer) }}')" class="py-4 max-w-6xl mx-auto sm:px-6 lg:px-8">
         @if (session('success'))
             <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
         @endif


### PR DESCRIPTION
## Summary
- add scrolling limit to tables
- remove pagination from table partials and controllers
- move Inventory link to top navigation bar and clean sidebar
- group sidebar links for services and configuration

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6851d27fb098832a986d9df6e8c46715