### PR TITLE
Add unified styling and modal alerts

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+    body {
+        @apply bg-gray-50 text-gray-800;
+    }
+}
+
+@layer components {
+    .btn-primary {
+        @apply px-4 py-2 rounded bg-primary text-white hover:bg-primary-light;
+    }
+    .btn-secondary {
+        @apply px-4 py-2 rounded bg-secondary text-white hover:bg-secondary-dark;
+    }
+}

--- a/resources/views/bank_accounts/create.blade.php
+++ b/resources/views/bank_accounts/create.blade.php
@@ -40,8 +40,8 @@
                     <input type="text" name="holder_cedula" required class="form-input w-full rounded border-gray-300 mt-1">
                 </div>
                 <div class="flex justify-end">
-                    <a href="{{ route('bank-accounts.index') }}" class="mr-3 px-4 py-2 bg-gray-300 text-gray-700 rounded">Cancelar</a>
-                    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Guardar</button>
+                    <a href="{{ route('bank-accounts.index') }}" class="mr-3 btn-secondary">Cancelar</a>
+                    <button type="submit" class="btn-primary">Guardar</button>
                 </div>
             </form>
         </div>

--- a/resources/views/bank_accounts/edit.blade.php
+++ b/resources/views/bank_accounts/edit.blade.php
@@ -41,8 +41,8 @@
                     <input type="text" name="holder_cedula" value="{{ old('holder_cedula', $bankAccount->holder_cedula) }}" required class="form-input w-full rounded border-gray-300 mt-1">
                 </div>
                 <div class="flex justify-end">
-                    <a href="{{ route('bank-accounts.index') }}" class="mr-3 px-4 py-2 bg-gray-300 text-gray-700 rounded">Cancelar</a>
-                    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Guardar</button>
+                    <a href="{{ route('bank-accounts.index') }}" class="mr-3 btn-secondary">Cancelar</a>
+                    <button type="submit" class="btn-primary">Guardar</button>
                 </div>
             </form>
         </div>

--- a/resources/views/bank_accounts/index.blade.php
+++ b/resources/views/bank_accounts/index.blade.php
@@ -11,6 +11,7 @@
                 <a href="{{ route('bank-accounts.create') }}" class="btn-primary">
                     Nueva Cuenta
                 </a>
+            </div>
 
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
                 <table class="min-w-full table-auto border">
@@ -44,4 +45,7 @@
                         @endforeach
                     </tbody>
                 </table>
+            </div>
+        </div>
+    </div>
 </x-app-layout>

--- a/resources/views/bank_accounts/index.blade.php
+++ b/resources/views/bank_accounts/index.blade.php
@@ -7,17 +7,10 @@
 
     <div class="py-4">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            @if (session('success'))
-                <div class="mb-4 font-medium text-sm text-green-600">
-                    {{ session('success') }}
-                </div>
-            @endif
-
             <div class="flex justify-end mb-4">
-                <a href="{{ route('bank-accounts.create') }}" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                <a href="{{ route('bank-accounts.create') }}" class="btn-primary">
                     Nueva Cuenta
                 </a>
-            </div>
 
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">
                 <table class="min-w-full table-auto border">
@@ -51,7 +44,4 @@
                         @endforeach
                     </tbody>
                 </table>
-            </div>
-        </div>
-    </div>
 </x-app-layout>

--- a/resources/views/components/primary-button.blade.php
+++ b/resources/views/components/primary-button.blade.php
@@ -1,3 +1,3 @@
-<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150']) }}>
+<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center btn-primary font-semibold text-xs uppercase focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150']) }}>
     {{ $slot }}
 </button>

--- a/resources/views/components/secondary-button.blade.php
+++ b/resources/views/components/secondary-button.blade.php
@@ -1,3 +1,3 @@
-<button {{ $attributes->merge(['type' => 'button', 'class' => 'inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-25 transition ease-in-out duration-150']) }}>
+<button {{ $attributes->merge(['type' => 'button', 'class' => 'inline-flex items-center btn-secondary font-semibold text-xs uppercase shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-25 transition ease-in-out duration-150']) }}>
     {{ $slot }}
 </button>

--- a/resources/views/discounts/create.blade.php
+++ b/resources/views/discounts/create.blade.php
@@ -5,7 +5,8 @@
         </h2>
     </x-slot>
 
-    <div class="py-6 max-w-4xl mx-auto sm:px-6 lg:px-8">
+    <div class="py-4">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
         <form method="POST" action="{{ route('discounts.store') }}" class="space-y-6">
             @csrf
             <div>
@@ -54,6 +55,7 @@
                 <x-primary-button class="ml-3">Guardar</x-primary-button>
             </div>
         </form>
+        </div>
     </div>
     <script>
         const itemSelect = document.querySelector('select[name="item"]');

--- a/resources/views/discounts/edit.blade.php
+++ b/resources/views/discounts/edit.blade.php
@@ -5,7 +5,8 @@
         </h2>
     </x-slot>
 
-    <div class="py-6 max-w-4xl mx-auto sm:px-6 lg:px-8">
+    <div class="py-4">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
         <form method="POST" action="{{ route('discounts.update', $discount) }}" class="space-y-6">
             @csrf
             @method('PUT')

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -6,12 +6,10 @@
     </x-slot>
 
     <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
-        @endif
+
 
         <div class="mb-4">
-            <a href="{{ route('discounts.create') }}" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Nuevo Descuento</a>
+            <a href="{{ route('discounts.create') }}" class="btn-primary">Nuevo Descuento</a>
         </div>
 
         <div class="bg-white shadow overflow-hidden sm:rounded-lg max-h-96 overflow-y-auto">

--- a/resources/views/drinks/create.blade.php
+++ b/resources/views/drinks/create.blade.php
@@ -33,10 +33,8 @@
             </div>
 
             <div class="flex items-center gap-4">
-                <button class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
-                    Guardar
-                </button>
-                <a href="{{ route('drinks.index') }}" class="text-gray-600 hover:underline">Cancelar</a>
+                <x-primary-button>Guardar</x-primary-button>
+                <x-secondary-button type="button" onclick="window.location='{{ route('drinks.index') }}'">Cancelar</x-secondary-button>
             </div>
         </form>
     </div>

--- a/resources/views/drinks/create.blade.php
+++ b/resources/views/drinks/create.blade.php
@@ -5,7 +5,8 @@
         </h2>
     </x-slot>
 
-    <div class="py-6 max-w-4xl mx-auto sm:px-6 lg:px-8">
+    <div class="py-4">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
         <form action="{{ route('drinks.store') }}" method="POST" class="space-y-6">
             @csrf
 
@@ -37,5 +38,6 @@
                 <x-secondary-button type="button" onclick="window.location='{{ route('drinks.index') }}'">Cancelar</x-secondary-button>
             </div>
         </form>
+        </div>
     </div>
 </x-app-layout>

--- a/resources/views/drinks/index.blade.php
+++ b/resources/views/drinks/index.blade.php
@@ -7,16 +7,10 @@
 
     <div x-data="filterTable('{{ route('drinks.index') }}', {selected: null})" x-on:click.away="selected = null" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">
-                {{ session('success') }}
-            </div>
-        @endif
 
         @if (auth()->user()->role === 'admin')
             <div class="mb-4 flex items-center gap-4">
-                <a href="{{ route('drinks.create') }}"
-                   class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">
+                <a href="{{ route('drinks.create') }}" class="btn-primary">
                     Nuevo Trago
                 </a>
                 <button x-show="selected" x-on:click="$dispatch('open-modal', 'edit-' + selected)" class="text-yellow-600" title="Editar">

--- a/resources/views/inventory/index.blade.php
+++ b/resources/views/inventory/index.blade.php
@@ -6,11 +6,6 @@
     </x-slot>
 
     <div x-data="filterTable('{{ route('inventory.index') }}')" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">
-                {{ session('success') }}
-            </div>
-        @endif
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
             <form method="GET" x-ref="form" class="flex items-end gap-2">
@@ -27,10 +22,10 @@
                     <input type="text" name="product" value="{{ $filters['product'] ?? '' }}" class="form-input" @input.debounce.500ms="fetchTable()">
                 </div>
             </form>
-            <a href="{{ route('inventory.create') }}" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">
+            <a href="{{ route('inventory.create') }}" class="btn-primary">
                 Nueva Entrada
             </a>
-            <a href="{{ route('inventory.createExit') }}" class="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded">
+            <a href="{{ route('inventory.createExit') }}" class="px-4 py-2 rounded bg-red-500 text-white hover:bg-red-600">
                 Nueva Salida
             </a>
         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,6 +21,7 @@
 
             <div class="flex-1">
                 @include('layouts.navigation')
+                @include('partials.flash-messages')
 
             <!-- Page Heading -->
             @if (isset($header))

--- a/resources/views/partials/flash-messages.blade.php
+++ b/resources/views/partials/flash-messages.blade.php
@@ -1,0 +1,23 @@
+@if (session('success'))
+    <x-modal name="flash-success" :show="true">
+        <div class="p-6">
+            <h2 class="text-lg font-medium text-gray-900 mb-4">Éxito</h2>
+            <p class="text-green-600">{{ session('success') }}</p>
+            <div class="mt-6 flex justify-end">
+                <x-secondary-button x-on:click="window.dispatchEvent(new CustomEvent('close-modal', { detail: 'flash-success' }))">Cerrar</x-secondary-button>
+            </div>
+        </div>
+    </x-modal>
+@endif
+
+@if (session('error'))
+    <x-modal name="flash-error" :show="true">
+        <div class="p-6">
+            <h2 class="text-lg font-medium text-gray-900 mb-4">Error</h2>
+            <p class="text-red-600">{{ session('error') }}</p>
+            <div class="mt-6 flex justify-end">
+                <x-secondary-button x-on:click="window.dispatchEvent(new CustomEvent('close-modal', { detail: 'flash-error' }))">Cerrar</x-secondary-button>
+            </div>
+        </div>
+    </x-modal>
+@endif

--- a/resources/views/petty_cash/index.blade.php
+++ b/resources/views/petty_cash/index.blade.php
@@ -6,9 +6,7 @@
     </x-slot>
 
     <div x-data="filterTable('{{ route('petty-cash.index') }}')" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
-        @endif
+
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
             <form method="GET" x-ref="form" class="flex items-end gap-2">
@@ -28,7 +26,7 @@
                     ">Ahora</button>
                 </div>
             </form>
-            <a href="{{ route('petty-cash.create') }}" class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600">Nuevo Gasto</a>
+            <a href="{{ route('petty-cash.create') }}" class="btn-primary">Nuevo Gasto</a>
         </div>
 
         <div class="mb-4 text-sm text-gray-700">

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -25,10 +25,8 @@
             </div>
 
             <div class="flex items-center gap-4">
-                <button class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
-                    Guardar
-                </button>
-                <a href="{{ route('products.index') }}" class="text-gray-600 hover:underline">Cancelar</a>
+                <x-primary-button>Guardar</x-primary-button>
+                <x-secondary-button type="button" onclick="window.location='{{ route('products.index') }}'">Cancelar</x-secondary-button>
             </div>
         </form>
     </div>

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -5,7 +5,8 @@
         </h2>
     </x-slot>
 
-    <div class="py-6 max-w-4xl mx-auto sm:px-6 lg:px-8">
+    <div class="py-4">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
         <form action="{{ route('products.store') }}" method="POST" class="space-y-6">
             @csrf
 
@@ -29,5 +30,6 @@
                 <x-secondary-button type="button" onclick="window.location='{{ route('products.index') }}'">Cancelar</x-secondary-button>
             </div>
         </form>
+        </div>
     </div>
 </x-app-layout>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -7,16 +7,10 @@
 
     <div x-data="filterTable('{{ route('products.index') }}', {selected: null})" x-on:click.away="selected = null" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">
-                {{ session('success') }}
-            </div>
-        @endif
 
         @if (auth()->user()->role === 'admin')
             <div class="mb-4 flex items-center gap-4">
-                <a href="{{ route('products.create') }}"
-                   class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">
+                <a href="{{ route('products.create') }}" class="btn-primary">
                     Nuevo Producto
                 </a>
                 <button x-show="selected" x-on:click="$dispatch('open-modal', 'edit-' + selected)" class="text-yellow-600" title="Editar">

--- a/resources/views/services/create.blade.php
+++ b/resources/views/services/create.blade.php
@@ -36,10 +36,8 @@
 
 
             <div class="flex items-center gap-4">
-                <button class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
-                    Guardar
-                </button>
-                <a href="{{ route('services.index') }}" class="text-gray-600 hover:underline">Cancelar</a>
+                <x-primary-button>Guardar</x-primary-button>
+                <x-secondary-button type="button" onclick="window.location='{{ route('services.index') }}'">Cancelar</x-secondary-button>
             </div>
         </form>
     </div>

--- a/resources/views/services/create.blade.php
+++ b/resources/views/services/create.blade.php
@@ -5,7 +5,8 @@
         </h2>
     </x-slot>
 
-    <div class="py-6 max-w-4xl mx-auto sm:px-6 lg:px-8">
+    <div class="py-4">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
         <form action="{{ route('services.store') }}" method="POST" class="space-y-6">
             @csrf
 
@@ -40,5 +41,6 @@
                 <x-secondary-button type="button" onclick="window.location='{{ route('services.index') }}'">Cancelar</x-secondary-button>
             </div>
         </form>
+        </div>
     </div>
 </x-app-layout>

--- a/resources/views/services/index.blade.php
+++ b/resources/views/services/index.blade.php
@@ -7,16 +7,10 @@
 
     <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">
-                {{ session('success') }}
-            </div>
-        @endif
 
         @if (auth()->user()->role === 'admin')
             <div class="mb-4">
-                <a href="{{ route('services.create') }}"
-                   class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">
+                <a href="{{ route('services.create') }}" class="btn-primary">
                     Nuevo Servicio
                 </a>
             </div>

--- a/resources/views/tickets/canceled.blade.php
+++ b/resources/views/tickets/canceled.blade.php
@@ -7,9 +7,6 @@
 
     <div x-data="filterTable('{{ route('tickets.canceled') }}', {selected: null})" x-on:click.away="selected = null" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
-        @endif
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
             <form method="GET" x-ref="form" class="flex items-end gap-2">

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -7,12 +7,6 @@
 
     <div x-data="filterTable('{{ route('tickets.index') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null, pending: {{ $filters['pending'] ?? 'null' }}})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
-        @endif
-        @if (session('error'))
-            <div class="mb-4 font-medium text-sm text-red-600">{{ session('error') }}</div>
-        @endif
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
             <form method="GET" x-ref="form" class="flex items-end gap-2">
@@ -28,7 +22,7 @@
             </form>
             <button type="button" class="px-4 py-2 text-white bg-red-500 rounded hover:bg-red-600" @click="pending = 1; fetchTable()">Pendientes</button>
             <button type="button" class="px-4 py-2 bg-gray-200 rounded" @click="pending = null; fetchTable()">Todos</button>
-            <a href="{{ route('tickets.create') }}" class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600">Nuevo Ticket</a>
+            <a href="{{ route('tickets.create') }}" class="btn-primary">Nuevo Ticket</a>
             <a href="{{ route('tickets.canceled') }}" class="text-blue-600 hover:underline">Ver cancelados</a>
             <button x-show="selected" x-on:click="openCancelModal()" class="text-red-600" title="Cancelar">
                 <i class="fa-solid fa-xmark fa-lg"></i>

--- a/resources/views/tickets/pending.blade.php
+++ b/resources/views/tickets/pending.blade.php
@@ -7,12 +7,6 @@
 
     <div x-data="filterTable('{{ route('tickets.pending') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
-        @endif
-        @if (session('error'))
-            <div class="mb-4 font-medium text-sm text-red-600">{{ session('error') }}</div>
-        @endif
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
             <form method="GET" x-ref="form" class="flex items-end gap-2">

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -7,14 +7,9 @@
 
     <div class="py-4">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            @if (session('success'))
-                <div class="mb-4 font-medium text-sm text-green-600">
-                    {{ session('success') }}
-                </div>
-            @endif
 
             <div class="flex justify-end mb-4">
-                <a href="{{ route('users.create') }}" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                <a href="{{ route('users.create') }}" class="btn-primary">
                     Nuevo Usuario
                 </a>
             </div>

--- a/resources/views/washers/index.blade.php
+++ b/resources/views/washers/index.blade.php
@@ -8,14 +8,9 @@
     <div class="py-4">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
 
-            @if (session('success'))
-                <div class="mb-4 font-medium text-sm text-green-600">
-                    {{ session('success') }}
-                </div>
-            @endif
 
             <div class="flex justify-between mb-4">
-                <a href="{{ route('washers.create') }}" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                <a href="{{ route('washers.create') }}" class="btn-primary">
                     Nuevo Lavador
                 </a>
                 <form action="{{ route('washers.payAll') }}" method="POST">

--- a/resources/views/washers/show.blade.php
+++ b/resources/views/washers/show.blade.php
@@ -6,9 +6,7 @@
     </x-slot>
 
     <div x-data="filterTable('{{ route('washers.show', $washer) }}')" class="py-4 max-w-6xl mx-auto sm:px-6 lg:px-8">
-        @if (session('success'))
-            <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
-        @endif
+
 
         <div class="mb-4">
             <a href="{{ route('washers.index') }}" class="text-blue-600 hover:underline">&larr; Volver a lista</a>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,18 @@ export default {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                primary: {
+                    DEFAULT: '#0d6efd',
+                    light: '#3b82f6',
+                    dark: '#0a58ca',
+                },
+                secondary: {
+                    DEFAULT: '#6c757d',
+                    light: '#adb5bd',
+                    dark: '#495057',
+                },
+            },
         },
     },
 


### PR DESCRIPTION
## Summary
- create global flash modal component
- add base colors, primary and secondary button classes
- integrate flash modals into main layout
- update Tailwind config with brand colors
- standardize buttons on several pages

## Testing
- `npm run build`
- `php artisan test --testsuite Unit --testsuite Feature`

------
https://chatgpt.com/codex/tasks/task_e_6851e1835f58832ab31a9c259765cfe0