### PR TITLE
Restrict mobile access

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -34,6 +34,7 @@ class Kernel extends HttpKernel
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\BlockMobileDevices::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
@@ -65,5 +66,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'role' => \App\Http\Middleware\RoleMiddleware::class,
+        'block.mobile' => \App\Http\Middleware\BlockMobileDevices::class,
     ];
 }

--- a/app/Http/Middleware/BlockMobileDevices.php
+++ b/app/Http/Middleware/BlockMobileDevices.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class BlockMobileDevices
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if ($this->isMobile($request)) {
+            return response()->view('mobile-warning');
+        }
+
+        return $next($request);
+    }
+
+    protected function isMobile(Request $request): bool
+    {
+        $agent = $request->header('User-Agent', '');
+        return (bool) preg_match('/(android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini|mobile|tablet)/i', $agent);
+    }
+}

--- a/resources/views/mobile-warning.blade.php
+++ b/resources/views/mobile-warning.blade.php
@@ -1,0 +1,6 @@
+<x-guest-layout>
+    <div class="text-center text-lg">
+        <p>Acceso temporalmente restringido para dispositivos móviles y tablets.</p>
+        <p>Por favor, ingresa desde un ordenador de escritorio.</p>
+    </div>
+</x-guest-layout>

--- a/tests/Feature/MobileAccessTest.php
+++ b/tests/Feature/MobileAccessTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MobileAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mobile_device_gets_warning_page(): void
+    {
+        $response = $this->withHeaders([
+            'User-Agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_6 like Mac OS X)'
+        ])->get('/login');
+
+        $response->assertStatus(200);
+        $response->assertSee('Acceso temporalmente restringido');
+    }
+
+    public function test_desktop_device_can_access_normally(): void
+    {
+        $response = $this->withHeaders([
+            'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'
+        ])->get('/login');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Acceso temporalmente restringido');
+    }
+}


### PR DESCRIPTION
## Summary
- block mobile and tablet devices using BlockMobileDevices middleware
- register middleware in Kernel
- add landing page for mobile users
- ensure functionality via new feature test

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685233749420832a8e1e9dd0cac98414