### PR TITLE
Fix date formats for 12‑hour display

### DIFF
--- a/app/Exports/DashboardExport.php
+++ b/app/Exports/DashboardExport.php
@@ -39,17 +39,17 @@ class DashboardExport implements WithMultipleSheets, Responsable
                         ->whereDate('created_at','<=',$this->end)->get();
                     $rows = [];
                     foreach($tickets as $t){
-                        $rows[] = ['Ticket '.$t->id, $t->created_at->format('d/m/Y H:i'), $t->total_amount];
+                        $rows[] = ['Ticket '.$t->id, $t->created_at->format('d/m/Y h:i A'), $t->total_amount];
                     }
                     $expenses = PettyCashExpense::whereDate('created_at','>=',$this->start)
                         ->whereDate('created_at','<=',$this->end)->get();
                     foreach($expenses as $e){
-                        $rows[] = ['Gasto', $e->created_at->format('d/m/Y H:i'), -$e->amount];
+                        $rows[] = ['Gasto', $e->created_at->format('d/m/Y h:i A'), -$e->amount];
                     }
                     $payments = WasherPayment::whereDate('payment_date','>=',$this->start)
                         ->whereDate('payment_date','<=',$this->end)->get();
                     foreach($payments as $p){
-                        $rows[] = ['Pago Lavador '.$p->washer->name, $p->payment_date, -$p->amount_paid];
+                        $rows[] = ['Pago Lavador '.$p->washer->name, $p->payment_date->format('d/m/Y h:i A'), -$p->amount_paid];
                     }
                     return collect($rows);
                 }
@@ -95,7 +95,7 @@ class DashboardExport implements WithMultipleSheets, Responsable
                         ->whereDate('payment_date','<=',$this->end)
                         ->get()->map(fn($p)=>[
                             $p->washer->name,
-                            $p->payment_date,
+                            $p->payment_date->format('d/m/Y h:i A'),
                             $p->amount_paid
                         ]);
                 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -111,21 +111,21 @@ class DashboardController extends Controller
         foreach ($tickets as $t) {
             $movements[] = [
                 'description' => 'Ticket '.$t->id,
-                'date' => $t->paid_at->format('d/m/Y H:i'),
+                'date' => $t->paid_at->format('d/m/Y h:i A'),
                 'amount' => $t->total_amount,
             ];
         }
         foreach ($pettyCashExpenses as $e) {
             $movements[] = [
                 'description' => 'Gasto: '.$e->description,
-                'date' => $e->created_at->format('d/m/Y H:i'),
+                'date' => $e->created_at->format('d/m/Y h:i A'),
                 'amount' => -$e->amount,
             ];
         }
         foreach (WasherPayment::whereDate('payment_date', '>=', $start)->whereDate('payment_date', '<=', $end)->get() as $p) {
             $movements[] = [
                 'description' => 'Pago Lavador '.$p->washer->name,
-                'date' => $p->payment_date,
+                'date' => $p->payment_date->format('d/m/Y h:i A'),
                 'amount' => -$p->amount_paid,
             ];
         }

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -28,7 +28,7 @@
                 <tbody>
                     @foreach($pendingTickets as $t)
                         <tr>
-                            <td class="border px-2 py-1">{{ $t->created_at->format('d/m H:i') }}</td>
+                            <td class="border px-2 py-1">{{ $t->created_at->format('d/m h:i A') }}</td>
                             <td class="border px-2 py-1">{{ $t->customer_name }}</td>
                             <td class="border px-2 py-1">
                                 {{ $t->details->pluck('type')->unique()->map(fn($tt) => match($tt){
@@ -63,7 +63,7 @@
             <h3 class="text-lg font-semibold mb-2">Últimos gastos de caja chica</h3>
             <ul class="list-disc ms-6">
                 @foreach($lastExpenses as $expense)
-                    <li>{{ $expense->created_at->format('d/m H:i') }} - {{ $expense->description }} (RD$ {{ number_format($expense->amount,2) }})</li>
+                    <li>{{ $expense->created_at->format('d/m h:i A') }} - {{ $expense->description }} (RD$ {{ number_format($expense->amount,2) }})</li>
                 @endforeach
             </ul>
         </div>

--- a/resources/views/discounts/index.blade.php
+++ b/resources/views/discounts/index.blade.php
@@ -46,7 +46,7 @@
                                 }
                             @endphp
                             <td class="px-3 py-2">{{ isset($final) ? 'RD$'.number_format($final,2) : '-' }}</td>
-                            <td class="px-3 py-2">{{ optional($d->end_at)->format('d/m/Y H:i') }}</td>
+                            <td class="px-3 py-2">{{ optional($d->end_at)->format('d/m/Y h:i A') }}</td>
                             <td class="px-3 py-2">{{ $d->active ? 'Activo' : 'Inactivo' }}</td>
                             <td class="px-3 py-2 text-right">
                                 <a href="{{ route('discounts.edit', $d) }}" class="text-blue-600">Editar</a>

--- a/resources/views/discounts/show.blade.php
+++ b/resources/views/discounts/show.blade.php
@@ -41,8 +41,8 @@
             @if(isset($final))
                 <div><strong>Precio con descuento:</strong> RD${{ number_format($final,2) }}</div>
             @endif
-            <div><strong>Inicio:</strong> {{ optional($discount->start_at)->format('d/m/Y H:i') }}</div>
-            <div><strong>Fin:</strong> {{ optional($discount->end_at)->format('d/m/Y H:i') }}</div>
+            <div><strong>Inicio:</strong> {{ optional($discount->start_at)->format('d/m/Y h:i A') }}</div>
+            <div><strong>Fin:</strong> {{ optional($discount->end_at)->format('d/m/Y h:i A') }}</div>
             <div><strong>Estado:</strong> {{ $discount->active ? 'Activo' : 'Inactivo' }}</div>
         </div>
 
@@ -51,7 +51,7 @@
             <ul class="list-disc pl-4">
                 @foreach($discount->logs as $log)
                     <li>
-                        {{ $log->created_at->format('d/m/Y H:i') }} - {{ $log->user->name }} ({{ $log->action }})
+                        {{ $log->created_at->format('d/m/Y h:i A') }} - {{ $log->user->name }} ({{ $log->action }})
                         @if($log->amount)
                             - {{ $log->amount_type === 'fixed' ? 'RD$'.number_format($log->amount,2) : $log->amount.'%' }}
                         @endif

--- a/resources/views/petty_cash/partials/table.blade.php
+++ b/resources/views/petty_cash/partials/table.blade.php
@@ -11,7 +11,7 @@
         <tbody>
             @foreach ($expenses as $expense)
                 <tr class="border-t">
-                    <td class="px-4 py-2">{{ $expense->created_at->format('d/m/Y H:i') }}</td>
+                    <td class="px-4 py-2">{{ $expense->created_at->format('d/m/Y h:i A') }}</td>
                     <td class="px-4 py-2">{{ $expense->description }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($expense->amount, 2) }}</td>
                     <td class="px-4 py-2">

--- a/resources/views/tickets/partials/canceled-table.blade.php
+++ b/resources/views/tickets/partials/canceled-table.blade.php
@@ -28,7 +28,7 @@
                     <td class="px-4 py-2">
                         {{ optional($ticket->bankAccount)->bank ? $ticket->bankAccount->bank.' - '.$ticket->bankAccount->account : '' }}
                     </td>
-                    <td class="px-4 py-2">{{ $ticket->created_at->format('d/m/Y H:i') }}</td>
+                    <td class="px-4 py-2">{{ $ticket->created_at->format('d/m/Y h:i A') }}</td>
                 </tr>
             @endforeach
         </tbody>
@@ -38,7 +38,7 @@
     <x-modal name="view-{{ $ticket->id }}" focusable>
         <div class="p-6 space-y-4 text-sm">
             <p><strong>Cliente:</strong> {{ $ticket->customer_name }}</p>
-            <p><strong>Fecha:</strong> {{ $ticket->created_at->format('d/m/Y H:i') }}</p>
+            <p><strong>Fecha:</strong> {{ $ticket->created_at->format('d/m/Y h:i A') }}</p>
             @if($ticket->vehicle)
                 <p><strong>Placa:</strong> {{ $ticket->vehicle->plate }}</p>
                 <p><strong>Marca:</strong> {{ $ticket->vehicle->brand }}</p>

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -34,7 +34,7 @@
                     <td class="px-4 py-2">
                         {{ optional($ticket->bankAccount)->bank ? $ticket->bankAccount->bank.' - '.$ticket->bankAccount->account : '' }}
                     </td>
-                    <td class="px-4 py-2">{{ $ticket->created_at->format('d/m/Y H:i') }}</td>
+                    <td class="px-4 py-2">{{ $ticket->created_at->format('d/m/Y h:i A') }}</td>
                 </tr>
             @endforeach
         </tbody>
@@ -98,7 +98,7 @@
             @method('PUT')
             <div class="text-sm space-y-1">
                 <p><strong>Cliente:</strong> {{ $ticket->customer_name }}</p>
-                <p><strong>Fecha:</strong> {{ $ticket->created_at->format('d/m/Y H:i') }}</p>
+                <p><strong>Fecha:</strong> {{ $ticket->created_at->format('d/m/Y h:i A') }}</p>
                 @if($ticket->vehicle)
                     <p><strong>Placa:</strong> {{ $ticket->vehicle->plate }}</p>
                     <p><strong>Marca:</strong> {{ $ticket->vehicle->brand }}</p>

--- a/resources/views/washers/partials/ledger.blade.php
+++ b/resources/views/washers/partials/ledger.blade.php
@@ -13,7 +13,7 @@
         <tbody>
             @foreach($events as $e)
                 <tr class="border-b">
-                    <td class="px-4 py-2">{{ \Carbon\Carbon::parse($e['date'])->format('d/m/Y H:i') }}</td>
+                    <td class="px-4 py-2">{{ \Carbon\Carbon::parse($e['date'])->format('d/m/Y h:i A') }}</td>
                     <td class="px-4 py-2">{{ $e['ticket_id'] ?? '' }}</td>
                     <td class="px-4 py-2">{{ $e['customer'] ?? '' }}</td>
                     <td class="px-4 py-2">{{ $e['description'] }}</td>


### PR DESCRIPTION
## Summary
- fix movement date for washer payments on dashboard
- export dates in 12‑hour format
- display times in 12‑hour format across dashboard, petty cash, washer ledger, tickets, and discounts

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6855fe25e068832a9afe1de977f14bd5