### PR TITLE
Implement washer debt ledger on ticket cancelation

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -7,6 +7,7 @@ use App\Models\Ticket;
 use App\Models\PettyCashExpense;
 use App\Models\WasherPayment;
 use App\Models\BankAccount;
+use App\Models\Washer;
 
 class DashboardController extends Controller
 {
@@ -105,6 +106,9 @@ class DashboardController extends Controller
 
         $accountsReceivable = $pendingTickets->sum('total_amount');
 
+        $washerDebts = Washer::where('pending_amount', '<', 0)->get();
+        $accountsReceivable += $washerDebts->sum(fn($w) => abs($w->pending_amount));
+
         $lastExpenses = $pettyCashExpenses->take(5);
 
         $movements = [];
@@ -150,7 +154,8 @@ class DashboardController extends Controller
                 'lastExpenses',
                 'movements',
                 'accountsReceivable',
-                'pendingTickets'
+                'pendingTickets',
+                'washerDebts'
             ));
         }
 
@@ -170,6 +175,7 @@ class DashboardController extends Controller
             'pettyCashTotal' => $pettyCashTotal,
             'accountsReceivable' => $accountsReceivable,
             'pendingTickets' => $pendingTickets,
+            'washerDebts' => $washerDebts,
         ]);
     }
 

--- a/app/Http/Controllers/WasherController.php
+++ b/app/Http/Controllers/WasherController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Washer;
 use App\Models\WasherPayment;
+use App\Models\WasherMovement;
 use Illuminate\Http\Request;
 
 class WasherController extends Controller
@@ -95,6 +96,15 @@ class WasherController extends Controller
         }
         $payments = $paymentsQuery->get();
 
+        $movementsQuery = $washer->movements();
+        if ($start) {
+            $movementsQuery->whereDate('created_at', '>=', $start);
+        }
+        if ($end) {
+            $movementsQuery->whereDate('created_at', '<=', $end);
+        }
+        $movements = $movementsQuery->get();
+
         $events = [];
         foreach ($tickets as $t) {
             $vehicle = $t->vehicle;
@@ -124,6 +134,17 @@ class WasherController extends Controller
                 'gain' => null,
                 'payment' => $p->amount_paid,
                 'ticket_id' => null,
+            ];
+        }
+
+        foreach ($movements as $m) {
+            $events[] = [
+                'date' => $m->created_at,
+                'customer' => null,
+                'description' => $m->description,
+                'gain' => $m->amount,
+                'payment' => null,
+                'ticket_id' => $m->ticket_id,
             ];
         }
         usort($events, fn($a, $b) => $a['date']->timestamp <=> $b['date']->timestamp);

--- a/app/Models/Washer.php
+++ b/app/Models/Washer.php
@@ -24,5 +24,10 @@ class Washer extends Model
     {
         return $this->hasMany(WasherPayment::class);
     }
+
+    public function movements()
+    {
+        return $this->hasMany(WasherMovement::class);
+    }
 }
 

--- a/app/Models/WasherMovement.php
+++ b/app/Models/WasherMovement.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class WasherMovement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'washer_id', 'ticket_id', 'amount', 'description'
+    ];
+
+    public function washer()
+    {
+        return $this->belongsTo(Washer::class);
+    }
+
+    public function ticket()
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+}

--- a/database/migrations/2025_06_20_230000_create_washer_movements_table.php
+++ b/database/migrations/2025_06_20_230000_create_washer_movements_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('washer_movements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('washer_id')->constrained()->onDelete('cascade');
+            $table->foreignId('ticket_id')->nullable()->constrained()->onDelete('set null');
+            $table->decimal('amount', 10, 2);
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('washer_movements');
+    }
+};

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -20,7 +20,7 @@
                 <thead class="bg-gray-200">
                     <tr>
                         <th class="border px-2 py-1">Fecha</th>
-                        <th class="border px-2 py-1">Cliente</th>
+                        <th class="border px-2 py-1">Nombre</th>
                         <th class="border px-2 py-1">Tipo</th>
                         <th class="border px-2 py-1">Total</th>
                     </tr>
@@ -43,7 +43,7 @@
                     @foreach($washerDebts as $w)
                         <tr>
                             <td class="border px-2 py-1">-</td>
-                            <td class="border px-2 py-1">{{ $w->name }}</td>
+                            <td class="border px-2 py-1">Lavador - {{ $w->name }}</td>
                             <td class="border px-2 py-1">Cuenta por cobrar</td>
                             <td class="border px-2 py-1 text-right">RD$ {{ number_format(abs($w->pending_amount),2) }}</td>
                         </tr>

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -40,6 +40,14 @@
                             <td class="border px-2 py-1 text-right">RD$ {{ number_format($t->total_amount,2) }}</td>
                         </tr>
                     @endforeach
+                    @foreach($washerDebts as $w)
+                        <tr>
+                            <td class="border px-2 py-1">-</td>
+                            <td class="border px-2 py-1">{{ $w->name }}</td>
+                            <td class="border px-2 py-1">Cuenta por cobrar</td>
+                            <td class="border px-2 py-1 text-right">RD$ {{ number_format(abs($w->pending_amount),2) }}</td>
+                        </tr>
+                    @endforeach
                 </tbody>
             </table>
         </div>

--- a/tests/Feature/WasherDebtTest.php
+++ b/tests/Feature/WasherDebtTest.php
@@ -1,0 +1,83 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Washer;
+use App\Models\Service;
+use App\Models\VehicleType;
+use App\Models\Ticket;
+use App\Models\TicketDetail;
+use App\Models\WasherPayment;
+use App\Models\WasherMovement;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WasherDebtTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cancel_paid_ticket_creates_washer_debt(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $washer = Washer::create([
+            'name' => 'Lavador',
+            'pending_amount' => 0,
+            'active' => true,
+        ]);
+
+        $vehicleType = VehicleType::create(['name' => 'Car']);
+        $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
+
+        $ticket = Ticket::create([
+            'user_id' => $user->id,
+            'washer_id' => $washer->id,
+            'vehicle_type_id' => $vehicleType->id,
+            'vehicle_id' => null,
+            'customer_name' => 'Cliente',
+            'customer_cedula' => null,
+            'total_amount' => 200,
+            'paid_amount' => 200,
+            'change' => 0,
+            'discount_total' => 0,
+            'payment_method' => 'efectivo',
+            'bank_account_id' => null,
+            'washer_pending_amount' => 0,
+            'canceled' => false,
+            'cancel_reason' => null,
+            'pending' => false,
+            'paid_at' => now(),
+        ]);
+
+        TicketDetail::create([
+            'ticket_id' => $ticket->id,
+            'type' => 'service',
+            'service_id' => $service->id,
+            'product_id' => null,
+            'drink_id' => null,
+            'quantity' => 1,
+            'unit_price' => 200,
+            'discount_amount' => 0,
+            'subtotal' => 200,
+        ]);
+
+        $washer->increment('pending_amount', 100);
+        WasherPayment::create([
+            'washer_id' => $washer->id,
+            'payment_date' => now(),
+            'total_washes' => 1,
+            'amount_paid' => 100,
+        ]);
+        $washer->update(['pending_amount' => 0]);
+
+        $this->actingAs($user)
+            ->post(route('tickets.cancel', $ticket), ['cancel_reason' => 'test']);
+
+        $this->assertDatabaseHas('washer_movements', [
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => -100,
+            'description' => 'Cuenta por cobrar - Ganancia de ticket cancelado',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- track washer debts in `washer_movements` table
- record a movement when canceling tickets
- display washer debts on washer dashboard
- show negative washer balances in dashboard accounts receivable
- test washer debt creation when canceling a paid ticket

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68563e263d68832a8f62b80102736e0e