### PR TITLE
Add payment date selections

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -16,6 +16,7 @@ use App\Models\Discount;
 use App\Models\BankAccount;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
 
 class TicketController extends Controller
 {
@@ -901,6 +902,7 @@ class TicketController extends Controller
             'payment_method' => 'required|in:efectivo,tarjeta,transferencia,mixto',
             'bank_account_id' => 'required_if:payment_method,transferencia|nullable|exists:bank_accounts,id',
             'paid_amount' => 'required|numeric|min:0',
+            'payment_date' => 'required|date',
         ]);
 
         if ($request->paid_amount < $ticket->total_amount) {
@@ -913,7 +915,7 @@ class TicketController extends Controller
             'paid_amount' => $request->paid_amount,
             'change' => $request->paid_amount - $ticket->total_amount,
             'pending' => false,
-            'paid_at' => now(),
+            'paid_at' => Carbon::parse($request->payment_date),
         ]);
 
         return redirect()->route('tickets.index')->with('success', 'Ticket pagado correctamente.');

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -75,6 +75,10 @@
                     <option value="mixto">Mixto</option>
                 </select>
             </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700">Fecha de Pago</label>
+                <input type="date" name="payment_date" value="{{ now()->toDateString() }}" class="form-input w-full" required>
+            </div>
             <div x-show="method === 'transferencia'">
                 <label class="block text-sm font-medium text-gray-700">Cuenta Bancaria</label>
                 <select name="bank_account_id" class="form-select w-full">

--- a/resources/views/washers/index.blade.php
+++ b/resources/views/washers/index.blade.php
@@ -13,14 +13,16 @@
                 <a href="{{ route('washers.create') }}" class="btn-primary">
                     Nuevo Lavador
                 </a>
-                <form action="{{ route('washers.payAll') }}" method="POST">
+                <form action="{{ route('washers.payAll') }}" method="POST" onsubmit="return confirm('Pagar todos los lavadores el '+this.payment_date.value+'?')">
                     @csrf
-                    <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">Pagar Todos</button>
+                    <input type="date" name="payment_date" value="{{ now()->toDateString() }}" class="form-input">
+                    <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 ms-2">Pagar Todos</button>
                 </form>
             </div>
 
             <div class="mb-4 bg-white p-4 shadow sm:rounded-lg">
                 <p>Total adeudado: <strong>RD$ {{ number_format($pendingTotal, 2) }}</strong></p>
+                <p>Pendiente de asignar: <strong>RD$ {{ number_format($unassignedTotal, 2) }}</strong></p>
             </div>
 
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg max-h-96 overflow-y-auto">

--- a/resources/views/washers/show.blade.php
+++ b/resources/views/washers/show.blade.php
@@ -19,9 +19,10 @@
                 @method('DELETE')
                 <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">Eliminar</button>
             </form>
-            <form action="{{ route('washers.pay', $washer) }}" method="POST">
+            <form action="{{ route('washers.pay', $washer) }}" method="POST" onsubmit="return confirm('Pagar a {{ $washer->name }} el '+this.payment_date.value+' por RD$ {{ number_format($washer->pending_amount,2) }}?')">
                 @csrf
-                <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">Marcar Pago</button>
+                <input type="date" name="payment_date" value="{{ now()->toDateString() }}" class="form-input">
+                <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 ms-2">Marcar Pago</button>
             </form>
         </div>
 

--- a/tests/Feature/PaymentDateTest.php
+++ b/tests/Feature/PaymentDateTest.php
@@ -1,0 +1,69 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\{User, Washer, Service, VehicleType, Ticket, TicketDetail};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class PaymentDateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ticket_payment_date_affects_dashboard()
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $washer = Washer::create(['name'=>'Lavador','pending_amount'=>0,'active'=>true]);
+        $vehicleType = VehicleType::create(['name'=>'Car']);
+        $service = Service::create(['name'=>'Lavado','description'=>'','active'=>true]);
+
+        $date = Carbon::yesterday();
+
+        $ticket = Ticket::create([
+            'user_id' => $user->id,
+            'washer_id' => $washer->id,
+            'vehicle_type_id' => $vehicleType->id,
+            'vehicle_id' => null,
+            'customer_name' => 'Cliente',
+            'customer_cedula' => null,
+            'total_amount' => 200,
+            'paid_amount' => 0,
+            'change' => 0,
+            'discount_total' => 0,
+            'payment_method' => 'efectivo',
+            'bank_account_id' => null,
+            'washer_pending_amount' => 0,
+            'canceled' => false,
+            'cancel_reason' => null,
+            'pending' => true,
+            'paid_at' => null,
+            'created_at' => $date,
+        ]);
+
+        TicketDetail::create([
+            'ticket_id' => $ticket->id,
+            'type' => 'service',
+            'service_id' => $service->id,
+            'product_id' => null,
+            'drink_id' => null,
+            'quantity' => 1,
+            'unit_price' => 200,
+            'discount_amount' => 0,
+            'subtotal' => 200,
+        ]);
+
+        $this->actingAs($user)->post(route('tickets.pay',$ticket),[
+            'payment_method' => 'efectivo',
+            'bank_account_id' => null,
+            'paid_amount' => 200,
+            'payment_date' => $date->toDateString(),
+        ]);
+
+        $ticket->refresh();
+        $this->assertEquals($date->toDateString(), $ticket->paid_at->toDateString());
+
+        $response = $this->actingAs($user)
+            ->get('/dashboard?start='.$date->toDateString().'&end='.$date->toDateString());
+        $this->assertEquals(200, $response->viewData('cashTotal'));
+    }
+}


### PR DESCRIPTION
## Summary
- allow custom payment date when paying tickets
- require payment date when paying washers
- show pending commission to assign on washers list
- prompt for payment date in washers screens and ticket payment modal
- test ticket payment date impacts dashboard

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685889e17cbc832abadfa5160b96cefc