### PR TITLE
Apply role-based limit for ticket edition/cancellation

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -530,6 +530,10 @@ class TicketController extends Controller
             abort(403);
         }
 
+        if ($ticket->created_at->lt(now()->subHours(6)) && auth()->user()->role === 'cajero') {
+            return redirect()->route('tickets.index')->with('error', 'No se puede editar un ticket con más de 6 horas de creado.');
+        }
+
         $services = Service::where('active', true)->with('prices')->get();
         $servicePrices = [];
         foreach ($services as $service) {
@@ -600,6 +604,9 @@ class TicketController extends Controller
 
     public function update(Request $request, Ticket $ticket)
     {
+        if ($ticket->created_at->lt(now()->subHours(6)) && auth()->user()->role === 'cajero') {
+            return back()->with('error', 'No se puede editar un ticket con más de 6 horas de creado.');
+        }
         if ($ticket->pending && $request->has('ticket_action')) {
             $pending = $request->input('ticket_action') === 'pending';
 
@@ -925,7 +932,7 @@ class TicketController extends Controller
             return redirect()->route('tickets.index');
         }
 
-        if ($ticket->created_at->lt(now()->subHours(6))) {
+        if ($ticket->created_at->lt(now()->subHours(6)) && auth()->user()->role === 'cajero') {
             return back()->with('error', 'No se puede cancelar un ticket con más de 6 horas de creado.');
         }
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -30,10 +30,32 @@ Alpine.data('filterTable', (url, extra = {}) => ({
         const created = new Date(this.selectedCreated);
         const diffHours = (Date.now() - created.getTime()) / 3600000;
         if (diffHours > 6) {
-            this.$dispatch('open-modal', 'cancel-error');
+            if (this.role === 'admin') {
+                if (confirm('Este ticket tiene más de 6 horas de creado. ¿Seguro que desea cancelarlo?')) {
+                    this.$dispatch('open-modal', 'cancel-' + this.selected);
+                }
+            } else {
+                this.$dispatch('open-modal', 'cancel-error');
+            }
         } else {
             this.$dispatch('open-modal', 'cancel-' + this.selected);
         }
+    },
+    openEdit() {
+        if (!this.selectedCreated || !this.selected) return;
+        const created = new Date(this.selectedCreated);
+        const diffHours = (Date.now() - created.getTime()) / 3600000;
+        if (diffHours > 6) {
+            if (this.role === 'admin') {
+                if (!confirm('Este ticket tiene más de 6 horas de creado. ¿Seguro que desea editarlo?')) {
+                    return;
+                }
+            } else {
+                alert('No se puede editar un ticket con más de 6 horas de creado.');
+                return;
+            }
+        }
+        window.location = `${this.editBase}/${this.selected}/edit`;
     }
 }));
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -30,13 +30,7 @@ Alpine.data('filterTable', (url, extra = {}) => ({
         const created = new Date(this.selectedCreated);
         const diffHours = (Date.now() - created.getTime()) / 3600000;
         if (diffHours > 6) {
-            if (this.role === 'admin') {
-                if (confirm('Este ticket tiene más de 6 horas de creado. ¿Seguro que desea cancelarlo?')) {
-                    this.$dispatch('open-modal', 'cancel-' + this.selected);
-                }
-            } else {
-                this.$dispatch('open-modal', 'cancel-error');
-            }
+            this.$dispatch('open-modal', 'cancel-error');
         } else {
             this.$dispatch('open-modal', 'cancel-' + this.selected);
         }

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -5,7 +5,7 @@
         </h2>
     </x-slot>
 
-    <div x-data="filterTable('{{ route('tickets.index') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null, pending: {{ $filters['pending'] ?? 'null' }}})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+    <div x-data="filterTable('{{ route('tickets.index') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null, pending: {{ $filters['pending'] ?? 'null' }}, role: '{{ Auth::user()->role }}', editBase: '{{ url('tickets') }}'})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
@@ -34,7 +34,7 @@
             <button x-show="selected" x-on:click="openCancelModal()" class="text-red-600" title="Cancelar">
                 <i class="fa-solid fa-xmark fa-lg"></i>
             </button>
-            <button x-show="selected" x-on:click="selectedPending ? window.location='{{ url('tickets') }}/'+selected+'/edit' : $dispatch('open-modal', 'view-' + selected)" class="text-gray-600" title="Ver/Editar">
+            <button x-show="selected" x-on:click="selectedPending ? openEdit() : $dispatch('open-modal', 'view-' + selected)" class="text-gray-600" title="Ver/Editar">
                 <i class="fa-solid fa-eye fa-lg"></i>
             </button>
             <button x-show="selected && selectedPending" x-on:click="$dispatch('open-modal', 'pay-' + selected)" class="text-green-600" title="Pagar">

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -49,6 +49,11 @@
                 <p>Este ticket tiene más de 6 horas de creado.</p>
                 <div class="mt-6 flex justify-end">
                     <x-secondary-button x-on:click="$dispatch('close')">Cerrar</x-secondary-button>
+                    @if(Auth::user()->role === 'admin')
+                        <x-danger-button class="ms-3" x-on:click="$dispatch('close'); $dispatch('open-modal', 'cancel-' + selected)">
+                            Continuar
+                        </x-danger-button>
+                    @endif
                 </div>
             </div>
         </x-modal>

--- a/resources/views/tickets/pending.blade.php
+++ b/resources/views/tickets/pending.blade.php
@@ -5,7 +5,7 @@
         </h2>
     </x-slot>
 
-    <div x-data="filterTable('{{ route('tickets.pending') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+    <div x-data="filterTable('{{ route('tickets.pending') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null, role: '{{ Auth::user()->role }}', editBase: '{{ url('tickets') }}'})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
@@ -32,7 +32,7 @@
             <button x-show="selected" x-on:click="openCancelModal()" class="text-red-600" title="Cancelar">
                 <i class="fa-solid fa-xmark fa-lg"></i>
             </button>
-            <button x-show="selected" x-on:click="window.location='{{ url('tickets') }}/'+selected+'/edit'" class="text-gray-600" title="Editar">
+            <button x-show="selected" x-on:click="openEdit()" class="text-gray-600" title="Editar">
                 <i class="fa-solid fa-eye fa-lg"></i>
             </button>
             <button x-show="selected && selectedPending" x-on:click="$dispatch('open-modal', 'pay-' + selected)" class="text-green-600" title="Pagar">

--- a/resources/views/tickets/pending.blade.php
+++ b/resources/views/tickets/pending.blade.php
@@ -47,6 +47,11 @@
                 <p>Este ticket tiene más de 6 horas de creado.</p>
                 <div class="mt-6 flex justify-end">
                     <x-secondary-button x-on:click="$dispatch('close')">Cerrar</x-secondary-button>
+                    @if(Auth::user()->role === 'admin')
+                        <x-danger-button class="ms-3" x-on:click="$dispatch('close'); $dispatch('open-modal', 'cancel-' + selected)">
+                            Continuar
+                        </x-danger-button>
+                    @endif
                 </div>
             </div>
         </x-modal>


### PR DESCRIPTION
## Summary
- enforce 6‑hour limit only for cashiers in TicketController
- let admins confirm edit/cancel actions after 6 hours in frontend
- add role/editBase params to ticket pages

## Testing
- `php artisan test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68692db0fbf4832abb3fb671184ba42c