### PR TITLE
Validate date range filters

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -19,6 +19,10 @@ class DashboardController extends Controller
 
     public function index(Request $request)
     {
+        $request->validate([
+            'start' => ['nullable', 'date', 'before_or_equal:end'],
+            'end' => ['nullable', 'date', 'after_or_equal:start'],
+        ]);
         $start = $request->input('start', now()->toDateString());
         $end = $request->input('end', now()->toDateString());
 
@@ -224,6 +228,10 @@ class DashboardController extends Controller
 
     public function download(Request $request)
     {
+        $request->validate([
+            'start' => ['nullable', 'date', 'before_or_equal:end'],
+            'end' => ['nullable', 'date', 'after_or_equal:start'],
+        ]);
         $start = $request->input('start', now()->toDateString());
         $end = $request->input('end', now()->toDateString());
 

--- a/app/Http/Controllers/DiscountController.php
+++ b/app/Http/Controllers/DiscountController.php
@@ -35,8 +35,8 @@ class DiscountController extends Controller
             'item' => 'required|string',
             'amount' => 'nullable|numeric|min:0',
             'amount_percentage' => 'nullable|numeric|min:0',
-            'start_at' => 'nullable|date',
-            'end_at' => 'nullable|date',
+            'start_at' => 'nullable|date|before_or_equal:end_at',
+            'end_at' => 'nullable|date|after_or_equal:start_at',
         ]);
 
         [$itemType, $id] = explode('-', $request->item);
@@ -95,8 +95,8 @@ class DiscountController extends Controller
             'item' => 'required|string',
             'amount' => 'nullable|numeric|min:0',
             'amount_percentage' => 'nullable|numeric|min:0',
-            'start_at' => 'nullable|date',
-            'end_at' => 'nullable|date',
+            'start_at' => 'nullable|date|before_or_equal:end_at',
+            'end_at' => 'nullable|date|after_or_equal:start_at',
         ]);
 
         [$itemType, $id] = explode('-', $request->item);

--- a/app/Http/Controllers/InventoryMovementController.php
+++ b/app/Http/Controllers/InventoryMovementController.php
@@ -15,6 +15,11 @@ class InventoryMovementController extends Controller
 
     public function index(Request $request)
     {
+        $request->validate([
+            'start' => ['nullable', 'date', 'before_or_equal:end'],
+            'end' => ['nullable', 'date', 'after_or_equal:start'],
+        ]);
+
         $query = InventoryMovement::with(['product', 'user']);
 
         if ($request->filled('start')) {

--- a/app/Http/Controllers/PettyCashExpenseController.php
+++ b/app/Http/Controllers/PettyCashExpenseController.php
@@ -14,6 +14,11 @@ class PettyCashExpenseController extends Controller
 
     public function index(Request $request)
     {
+        $request->validate([
+            'start' => ['nullable', 'date', 'before_or_equal:end'],
+            'end' => ['nullable', 'date', 'after_or_equal:start'],
+        ]);
+
         $filters = $request->only(['start', 'end']);
         $filters['start'] = $filters['start'] ?? now()->toDateString();
         $filters['end'] = $filters['end'] ?? now()->toDateString();

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -27,6 +27,10 @@ class TicketController extends Controller
 
     public function index(Request $request)
     {
+        $request->validate([
+            'start' => ['nullable', 'date', 'before_or_equal:end'],
+            'end' => ['nullable', 'date', 'after_or_equal:start'],
+        ]);
         $filters = $request->only(['start', 'end', 'pending']);
         $filters['start'] = $filters['start'] ?? now()->toDateString();
         $filters['end'] = $filters['end'] ?? now()->toDateString();
@@ -79,6 +83,10 @@ class TicketController extends Controller
 
     public function canceled(Request $request)
     {
+        $request->validate([
+            'start' => ['nullable', 'date', 'before_or_equal:end'],
+            'end' => ['nullable', 'date', 'after_or_equal:start'],
+        ]);
         $query = Ticket::with(['details', 'bankAccount'])->where('canceled', true);
 
         if ($request->filled('start')) {
@@ -105,6 +113,10 @@ class TicketController extends Controller
 
     public function pending(Request $request)
     {
+        $request->validate([
+            'start' => ['nullable', 'date', 'before_or_equal:end'],
+            'end' => ['nullable', 'date', 'after_or_equal:start'],
+        ]);
         $filters = $request->only(['start', 'end']);
         $filters['start'] = $filters['start'] ?? now()->toDateString();
         $filters['end'] = $filters['end'] ?? now()->toDateString();

--- a/app/Http/Controllers/WasherController.php
+++ b/app/Http/Controllers/WasherController.php
@@ -18,6 +18,10 @@ class WasherController extends Controller
 
     public function index(Request $request)
     {
+        $request->validate([
+            'start' => ['nullable', 'date', 'before_or_equal:end'],
+            'end' => ['nullable', 'date', 'after_or_equal:start'],
+        ]);
         $filters = $request->only(['start', 'end']);
         $filters['start'] = $filters['start'] ?? now()->toDateString();
         $filters['end'] = $filters['end'] ?? now()->toDateString();
@@ -125,6 +129,10 @@ class WasherController extends Controller
     public function show(Request $request, Washer $washer)
     {
         $today = now()->toDateString();
+        $request->validate([
+            'start' => ['nullable', 'date', 'before_or_equal:end'],
+            'end' => ['nullable', 'date', 'after_or_equal:start'],
+        ]);
 
         $start = $request->input('start', $today);
         $end = $request->input('end', $today);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,6 +9,16 @@ Alpine.data('filterTable', (url, extra = {}) => ({
     tableHtml: '',
     fetchTable() {
         const form = this.$refs.form;
+        const startInput = form.querySelector('[name="start"]');
+        const endInput = form.querySelector('[name="end"]');
+        if (startInput && endInput) {
+            endInput.min = startInput.value;
+            startInput.max = endInput.value;
+            if (startInput.value && endInput.value && startInput.value > endInput.value) {
+                alert('La fecha de inicio no puede ser mayor a la fecha de término.');
+                return;
+            }
+        }
         const params = new URLSearchParams(new FormData(form));
         params.set('pending', this.pending);
         params.append('ajax', '1');

--- a/resources/views/discounts/create.blade.php
+++ b/resources/views/discounts/create.blade.php
@@ -61,6 +61,8 @@
         const itemSelect = document.querySelector('select[name="item"]');
         const percent = document.getElementById('amount_percentage');
         const fixed = document.getElementById('amount_fixed');
+        const startAt = document.querySelector('input[name="start_at"]');
+        const endAt = document.querySelector('input[name="end_at"]');
         function getPrice() {
             if (itemSelect.value) {
                 return parseFloat(itemSelect.options[itemSelect.selectedIndex].dataset.price || 0);
@@ -81,5 +83,17 @@
         }
         percent.addEventListener('input', syncFromPercent);
         fixed.addEventListener('input', syncFromFixed);
+        function syncDates(){
+            if (startAt && endAt){
+                endAt.min = startAt.value;
+                startAt.max = endAt.value;
+                if(startAt.value && endAt.value && startAt.value > endAt.value){
+                    endAt.value = startAt.value;
+                }
+            }
+        }
+        startAt.addEventListener('change', syncDates);
+        endAt.addEventListener('change', syncDates);
+        document.addEventListener('DOMContentLoaded', syncDates);
     </script>
 </x-app-layout>

--- a/resources/views/discounts/edit.blade.php
+++ b/resources/views/discounts/edit.blade.php
@@ -82,6 +82,8 @@
         const itemSelect = document.querySelector('select[name="item"]');
         const percent = document.getElementById('amount_percentage');
         const fixed = document.getElementById('amount_fixed');
+        const startAt = document.querySelector('input[name="start_at"]');
+        const endAt = document.querySelector('input[name="end_at"]');
         function getPrice(){
             if(itemSelect.value){
                 return parseFloat(itemSelect.options[itemSelect.selectedIndex].dataset.price || 0);
@@ -108,6 +110,18 @@
             } else if(fixed.value){
                 syncFromFixed();
             }
+            syncDates();
         });
+        function syncDates(){
+            if(startAt && endAt){
+                endAt.min = startAt.value;
+                startAt.max = endAt.value;
+                if(startAt.value && endAt.value && startAt.value > endAt.value){
+                    endAt.value = startAt.value;
+                }
+            }
+        }
+        startAt.addEventListener('change', syncDates);
+        endAt.addEventListener('change', syncDates);
     </script>
 </x-app-layout>


### PR DESCRIPTION
## Summary
- Validate start/end date filters across controllers and discount management
- Prevent inverted date ranges client-side and synchronize date picker limits

## Testing
- `npm run build`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c6a948c8832ab30b4a9341c19916