### PR TITLE
feat: add tips and extra charges to tickets

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -95,7 +95,15 @@ class DashboardController extends Controller
             ->groupBy('bank_account_id')
             ->get();
 
-        $washerPayTotal = $washCount * 100;
+        $tipTotal = TicketWash::whereHas('ticket', function($q) use ($start, $end) {
+                $q->where('canceled', false)
+                  ->where('pending', false)
+                  ->whereDate('paid_at', '>=', $start)
+                  ->whereDate('paid_at', '<=', $end);
+            })
+            ->sum('tip');
+
+        $washerPayTotal = $washCount * 100 + $tipTotal;
 
         $pettyCashExpenses = PettyCashExpense::whereDate('created_at', '>=', $start)
             ->whereDate('created_at', '<=', $end)

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -141,7 +141,8 @@ class DashboardController extends Controller
                   ->whereDate('created_at', '<=', $end);
             })
             ->whereNotNull('washer_id')
-            ->count() * 100;
+            ->selectRaw('SUM(100 + tip) as total')
+            ->value('total') ?? 0;
 
         $lastExpenses = $pettyCashExpenses->take(5);
 
@@ -171,7 +172,7 @@ class DashboardController extends Controller
 
         $washerPayDue = 0;
         foreach (Washer::all() as $w) {
-            $wq = $w->ticketWashes()->where('washer_paid', false)->whereHas('ticket', function($q) use ($start, $end) {
+            $wq = $w->ticketWashes()->whereHas('ticket', function($q) use ($start, $end) {
                 $q->whereDate('created_at', '>=', $start)->whereDate('created_at', '<=', $end);
             });
             $ticketsTotal = $wq->count() * 100;

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -103,7 +103,26 @@ class DashboardController extends Controller
             })
             ->sum('tip');
 
-        $washerPayTotal = $washCount * 100 + $tipTotal;
+        $extraCommission = TicketWash::whereHas('ticket', function($q) use ($start, $end) {
+                $q->where('canceled', true)
+                  ->where('keep_commission_on_cancel', true)
+                  ->where('pending', false)
+                  ->whereDate('paid_at', '>=', $start)
+                  ->whereDate('paid_at', '<=', $end);
+            })
+            ->whereNotNull('washer_id')
+            ->count() * 100;
+
+        $extraTip = TicketWash::whereHas('ticket', function($q) use ($start, $end) {
+                $q->where('canceled', true)
+                  ->where('keep_tip_on_cancel', true)
+                  ->where('pending', false)
+                  ->whereDate('paid_at', '>=', $start)
+                  ->whereDate('paid_at', '<=', $end);
+            })
+            ->sum('tip');
+
+        $washerPayTotal = $washCount * 100 + $tipTotal + $extraCommission + $extraTip;
 
         $pettyCashExpenses = PettyCashExpense::whereDate('created_at', '>=', $start)
             ->whereDate('created_at', '<=', $end)

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -128,8 +128,7 @@ class DashboardController extends Controller
             ->get();
         $accountsReceivable += $washerDebts->sum(fn($m) => abs($m->amount));
 
-        $unassignedCommission = Ticket::where('pending', true)
-            ->where('canceled', false)
+        $unassignedCommission = Ticket::where('canceled', false)
             ->where('washer_pending_amount', '>', 0)
             ->whereDate('created_at', '>=', $start)
             ->whereDate('created_at', '<=', $end)

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -1067,21 +1067,13 @@ class TicketController extends Controller
         $hasCommission = $ticket->washes->whereNotNull('washer_id')->isNotEmpty();
         $hasTip = $ticket->washes->sum('tip') > 0;
         $rules = ['cancel_reason' => 'required|string|max:255'];
-        if ($hasCommission && $hasTip) {
-            $rules['pay_commission'] = 'nullable|in:yes,no';
-            $rules['pay_tip'] = 'nullable|in:yes,no';
-        } elseif ($hasCommission) {
-            $rules['pay_commission'] = 'required|in:yes,no';
-        } elseif ($hasTip) {
-            $rules['pay_tip'] = 'required|in:yes,no';
+        if ($hasCommission || $hasTip) {
+            $rules['pay_washer'] = 'required|in:yes,no';
         }
         $request->validate($rules);
-        if ($hasCommission && $hasTip && is_null($request->pay_commission) && is_null($request->pay_tip)) {
-            return back()->withErrors(['pay_commission' => 'Debe seleccionar una opción de pago.']);
-        }
 
-        $payCommission = $request->input('pay_commission') === 'yes';
-        $payTip = $request->input('pay_tip') === 'yes';
+        $payCommission = $hasCommission ? $request->input('pay_washer') === 'yes' : true;
+        $payTip = $hasTip ? $request->input('pay_washer') === 'yes' : true;
         $cancelReason = $request->cancel_reason;
 
         DB::transaction(function() use ($ticket, $payCommission, $payTip, $hasCommission, $hasTip, $cancelReason) {

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -1116,7 +1116,10 @@ class TicketController extends Controller
                         if ($payCommission) {
                             WasherPayment::where('washer_id', $wash->washer_id)
                                 ->whereDate('payment_date', $ticket->created_at->toDateString())
-                                ->update(['canceled_ticket' => true]);
+                                ->update([
+                                    'canceled_ticket' => true,
+                                    'payment_date' => DB::raw('payment_date'),
+                                ]);
                         } else {
                             WasherMovement::create([
                                 'washer_id' => $wash->washer_id,
@@ -1140,7 +1143,10 @@ class TicketController extends Controller
                             if ($payTip) {
                                 WasherPayment::where('washer_id', $wash->washer_id)
                                     ->whereDate('payment_date', $ticket->created_at->toDateString())
-                                    ->update(['canceled_ticket' => true]);
+                                    ->update([
+                                        'canceled_ticket' => true,
+                                        'payment_date' => DB::raw('payment_date'),
+                                    ]);
                             } else {
                                 WasherMovement::create([
                                     'washer_id' => $wash->washer_id,

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -488,26 +488,6 @@ class TicketController extends Controller
                 }
             }
 
-            if ($request->charge_descriptions) {
-                foreach ($request->charge_descriptions as $i => $desc) {
-                    $amount = floatval($request->charge_amounts[$i] ?? 0);
-                    if ($desc && $amount > 0) {
-                        $details[] = [
-                            'type' => 'extra',
-                            'service_id' => null,
-                            'product_id' => null,
-                            'drink_id' => null,
-                            'quantity' => 1,
-                            'unit_price' => $amount,
-                            'discount_amount' => 0,
-                            'subtotal' => $amount,
-                            'description' => $desc,
-                        ];
-                        $total += $amount;
-                    }
-                }
-            }
-
             if (count($details) === 0) {
                 DB::rollBack();
                 $message = ['service_ids' => ['Debe agregar al menos un servicio, producto o trago']];

--- a/app/Http/Controllers/WasherController.php
+++ b/app/Http/Controllers/WasherController.php
@@ -61,7 +61,7 @@ class WasherController extends Controller
 
         $unassignedQuery = TicketWash::whereNull('washer_id')
             ->whereHas('ticket', function ($q) use ($filters) {
-                $q->where('pending', true)->where('canceled', false);
+                $q->where('canceled', false);
                 if ($filters['start']) {
                     $q->whereDate('created_at', '>=', $filters['start']);
                 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -15,6 +15,7 @@ class Ticket extends Model
         'total_amount', 'paid_amount', 'change', 'discount_total',
         'payment_method', 'bank_account_id',
         'washer_pending_amount', 'canceled', 'cancel_reason',
+        'keep_commission_on_cancel', 'keep_tip_on_cancel',
         'pending', 'paid_at', 'created_at'
     ];
 
@@ -22,6 +23,8 @@ class Ticket extends Model
         'canceled' => 'boolean',
         'pending' => 'boolean',
         'paid_at' => 'datetime',
+        'keep_commission_on_cancel' => 'boolean',
+        'keep_tip_on_cancel' => 'boolean',
     ];
 
     public function user()

--- a/app/Models/TicketDetail.php
+++ b/app/Models/TicketDetail.php
@@ -11,7 +11,7 @@ class TicketDetail extends Model
 
     protected $fillable = [
         'ticket_id', 'ticket_wash_id', 'type', 'service_id',
-        'product_id', 'drink_id', 'quantity', 'unit_price', 'discount_amount', 'subtotal'
+        'product_id', 'drink_id', 'quantity', 'unit_price', 'discount_amount', 'subtotal', 'description'
     ];
 
     public function ticket()

--- a/app/Models/TicketWash.php
+++ b/app/Models/TicketWash.php
@@ -15,10 +15,12 @@ class TicketWash extends Model
         'vehicle_type_id',
         'washer_id',
         'washer_paid',
+        'tip',
     ];
 
     protected $casts = [
         'washer_paid' => 'boolean',
+        'tip' => 'float',
     ];
 
     public function ticket()

--- a/app/Models/WasherMovement.php
+++ b/app/Models/WasherMovement.php
@@ -9,7 +9,7 @@ class WasherMovement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'washer_id', 'ticket_id', 'amount', 'description', 'paid'
+        'washer_id', 'ticket_id', 'amount', 'description', 'paid', 'created_at', 'updated_at'
     ];
 
     protected $casts = [

--- a/app/Models/WasherMovement.php
+++ b/app/Models/WasherMovement.php
@@ -9,7 +9,11 @@ class WasherMovement extends Model
     use HasFactory;
 
     protected $fillable = [
-        'washer_id', 'ticket_id', 'amount', 'description'
+        'washer_id', 'ticket_id', 'amount', 'description', 'paid'
+    ];
+
+    protected $casts = [
+        'paid' => 'boolean',
     ];
 
     public function washer()

--- a/app/Models/WasherPayment.php
+++ b/app/Models/WasherPayment.php
@@ -9,11 +9,12 @@ class WasherPayment extends Model
     use HasFactory;
 
     protected $fillable = [
-        'washer_id', 'payment_date', 'total_washes', 'amount_paid', 'observations'
+        'washer_id', 'payment_date', 'total_washes', 'amount_paid', 'observations', 'canceled_ticket'
     ];
 
     protected $casts = [
         'payment_date' => 'datetime',
+        'canceled_ticket' => 'boolean',
     ];
 
     public function washer()

--- a/database/migrations/2025_08_23_041141_add_tip_to_ticket_washes_table.php
+++ b/database/migrations/2025_08_23_041141_add_tip_to_ticket_washes_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('ticket_washes', function (Blueprint $table) {
+            if (!Schema::hasColumn('ticket_washes', 'tip')) {
+                $table->decimal('tip', 10, 2)->default(0);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ticket_washes', function (Blueprint $table) {
+            if (Schema::hasColumn('ticket_washes', 'tip')) {
+                $table->dropColumn('tip');
+            }
+        });
+    }
+};

--- a/database/migrations/2025_08_23_041142_add_description_to_ticket_details_table.php
+++ b/database/migrations/2025_08_23_041142_add_description_to_ticket_details_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('ticket_details', function (Blueprint $table) {
+            if (!Schema::hasColumn('ticket_details', 'description')) {
+                $table->string('description')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ticket_details', function (Blueprint $table) {
+            if (Schema::hasColumn('ticket_details', 'description')) {
+                $table->dropColumn('description');
+            }
+        });
+    }
+};

--- a/database/migrations/2025_08_23_041143_add_paid_to_washer_movements_table.php
+++ b/database/migrations/2025_08_23_041143_add_paid_to_washer_movements_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('washer_movements', function (Blueprint $table) {
+            if (!Schema::hasColumn('washer_movements', 'paid')) {
+                $table->boolean('paid')->default(false);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('washer_movements', function (Blueprint $table) {
+            if (Schema::hasColumn('washer_movements', 'paid')) {
+                $table->dropColumn('paid');
+            }
+        });
+    }
+};

--- a/database/migrations/2025_08_23_041144_add_extra_type_to_ticket_details_table.php
+++ b/database/migrations/2025_08_23_041144_add_extra_type_to_ticket_details_table.php
@@ -1,0 +1,59 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            Schema::create('ticket_details_tmp', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('ticket_id')->constrained()->onDelete('cascade');
+                $table->foreignId('ticket_wash_id')->nullable()->constrained('ticket_washes')->onDelete('cascade');
+                $table->string('type');
+                $table->foreignId('service_id')->nullable()->constrained()->onDelete('set null');
+                $table->foreignId('product_id')->nullable()->constrained()->onDelete('set null');
+                $table->foreignId('drink_id')->nullable()->constrained()->onDelete('set null');
+                $table->integer('quantity')->default(1);
+                $table->decimal('unit_price', 10, 2);
+                $table->decimal('discount_amount', 10, 2)->default(0);
+                $table->decimal('subtotal', 10, 2);
+                $table->string('description')->nullable();
+                $table->timestamps();
+            });
+            DB::statement('INSERT INTO ticket_details_tmp SELECT * FROM ticket_details');
+            Schema::drop('ticket_details');
+            Schema::rename('ticket_details_tmp', 'ticket_details');
+        } else {
+            DB::statement("ALTER TABLE ticket_details MODIFY type ENUM('service','product','drink','extra')");
+        }
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            Schema::create('ticket_details_tmp', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('ticket_id')->constrained()->onDelete('cascade');
+                $table->foreignId('ticket_wash_id')->nullable()->constrained('ticket_washes')->onDelete('cascade');
+                $table->string('type');
+                $table->foreignId('service_id')->nullable()->constrained()->onDelete('set null');
+                $table->foreignId('product_id')->nullable()->constrained()->onDelete('set null');
+                $table->foreignId('drink_id')->nullable()->constrained()->onDelete('set null');
+                $table->integer('quantity')->default(1);
+                $table->decimal('unit_price', 10, 2);
+                $table->decimal('discount_amount', 10, 2)->default(0);
+                $table->decimal('subtotal', 10, 2);
+                $table->string('description')->nullable();
+                $table->timestamps();
+            });
+            DB::statement("INSERT INTO ticket_details_tmp SELECT * FROM ticket_details");
+            Schema::drop('ticket_details');
+            Schema::rename('ticket_details_tmp', 'ticket_details');
+        } else {
+            DB::statement("ALTER TABLE ticket_details MODIFY type ENUM('service','product','drink')");
+        }
+    }
+};

--- a/database/migrations/2025_08_24_000000_add_cancel_flags_to_tickets_and_payments.php
+++ b/database/migrations/2025_08_24_000000_add_cancel_flags_to_tickets_and_payments.php
@@ -1,0 +1,42 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            if (!Schema::hasColumn('tickets', 'keep_commission_on_cancel')) {
+                $table->boolean('keep_commission_on_cancel')->nullable();
+            }
+            if (!Schema::hasColumn('tickets', 'keep_tip_on_cancel')) {
+                $table->boolean('keep_tip_on_cancel')->nullable();
+            }
+        });
+
+        Schema::table('washer_payments', function (Blueprint $table) {
+            if (!Schema::hasColumn('washer_payments', 'canceled_ticket')) {
+                $table->boolean('canceled_ticket')->default(false);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            if (Schema::hasColumn('tickets', 'keep_commission_on_cancel')) {
+                $table->dropColumn('keep_commission_on_cancel');
+            }
+            if (Schema::hasColumn('tickets', 'keep_tip_on_cancel')) {
+                $table->dropColumn('keep_tip_on_cancel');
+            }
+        });
+
+        Schema::table('washer_payments', function (Blueprint $table) {
+            if (Schema::hasColumn('washer_payments', 'canceled_ticket')) {
+                $table->dropColumn('canceled_ticket');
+            }
+        });
+    }
+};

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -34,7 +34,9 @@
                                 {{ $t->details->pluck('type')->unique()->map(fn($tt) => match($tt){
                                     'service' => 'Lavado',
                                     'product' => 'Producto',
-                                    'drink' => 'Tragos'
+                                    'drink' => 'Tragos',
+                                    'extra' => 'Cargo',
+                                    default => ''
                                 })->implode(', ') }}
                             </td>
                             <td class="border px-2 py-1 text-right">RD$ {{ number_format($t->total_amount,2) }}</td>

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -87,6 +87,12 @@
                         </div>
                     </div>
 
+                    <!-- Propina -->
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Propina</label>
+                        <input type="number" name="temp_tip" min="0" step="0.01" class="form-input w-full mt-1">
+                    </div>
+
                     <!-- Lista Servicios -->
                     <div>
                         <label class="block text-sm font-medium text-gray-700">Servicios Realizados</label>
@@ -99,7 +105,7 @@
                         @endforeach
                         </div>
                     </div>
-                    <div class="mt-2 space-x-2">
+                <div class="mt-2 space-x-2">
                         <button type="button" id="save-wash-btn" class="px-3 py-1 text-sm text-white bg-blue-600 rounded hover:bg-blue-700" onclick="saveWash()">Agregar lavado</button>
                         <button type="button" id="cancel-wash-btn" class="px-3 py-1 text-sm text-gray-700 bg-gray-200 rounded hover:bg-gray-300 hidden" onclick="cancelWashForm()">Cancelar</button>
                     </div>
@@ -125,6 +131,15 @@
                 <div class="mt-4">
                     <div id="product-list"></div>
                     <button type="button" onclick="addProductRow()" class="mt-2 text-sm text-blue-600 hover:underline">+ Agregar otro producto</button>
+                </div>
+            </details>
+
+            <!-- Cargos adicionales -->
+            <details class="border rounded p-4" id="charge-section">
+                <summary class="cursor-pointer font-medium text-gray-700">Cargos Adicionales</summary>
+                <div class="mt-4">
+                    <div id="charge-list"></div>
+                    <button type="button" onclick="addChargeRow()" class="mt-2 text-sm text-blue-600 hover:underline">+ Agregar cargo</button>
                 </div>
             </details>
 
@@ -243,6 +258,11 @@
                 total += price * qty;
             });
 
+            document.querySelectorAll('#charge-list > div').forEach(row => {
+                const amount = parseFloat(row.querySelector('input[name="charge_amounts[]"]').value) || 0;
+                total += amount;
+            });
+
             currentTotal = total;
             currentDiscount = discount;
             document.getElementById('total_amount').innerText = formatCurrency(total);
@@ -350,6 +370,18 @@
             convertSelectToSearchable(row.querySelector('select'));
         }
 
+        function addChargeRow() {
+            const container = document.getElementById('charge-list');
+            const row = document.createElement('div');
+            row.classList.add('flex', 'gap-4', 'mb-2', 'items-center');
+            row.innerHTML = `
+                <input type="text" name="charge_descriptions[]" placeholder="Descripción" class="form-input w-full" />
+                <input type="number" name="charge_amounts[]" placeholder="Monto" step="0.01" class="form-input w-32" oninput="updateTotal()" />
+                <button type="button" class="text-red-600" onclick="this.parentElement.remove(); updateTotal();">x</button>
+            `;
+            container.appendChild(row);
+        }
+
         function showWashForm() {
             const form = document.getElementById('wash-form');
             document.getElementById('show-wash-form-btn').classList.add('hidden');
@@ -408,6 +440,8 @@
                 }
                 washTotal += price;
             });
+            const tip = parseFloat(form.querySelector('input[name="temp_tip"]').value) || 0;
+            washTotal += tip;
 
             const summary = `${brand} | ${model} | ${color} | ${year} | ${vehicleTypeName}`;
             let wrapper;
@@ -432,13 +466,15 @@
                 `<input type="hidden" name="washes[${index}][year]" value="${year}">` +
                 `<input type="hidden" name="washes[${index}][vehicle_type_id]" value="${vehicleTypeId}">` +
                 `<input type="hidden" name="washes[${index}][washer_id]" value="${washerId}">` +
-                `<div class="mt-2 space-y-1 text-sm"><p>Placa: ${plate}</p><p>Lavador: ${washerName || 'N/A'}</p><p>Servicios: ${servicesText}</p></div>`;
+                `<input type="hidden" name="washes[${index}][tip]" value="${tip.toFixed(2)}">` +
+                `<div class="mt-2 space-y-1 text-sm"><p>Placa: ${plate}</p><p>Lavador: ${washerName || 'N/A'}</p><p>Servicios: ${servicesText}</p><p>Propina: RD$ ${tip.toFixed(2)}</p></div>`;
 
             updateWashIndexes();
 
             form.querySelectorAll('input[type=text], input[type=number]').forEach(el=>el.value='');
             form.querySelectorAll('select').forEach(sel=>{sel.value=''; if(sel._searchInput) sel._searchInput.value='';});
             form.querySelectorAll('input[type=checkbox]').forEach(cb=>cb.checked=false);
+            form.querySelector('input[name="temp_tip"]').value='';
             delete form.dataset.editIndex;
             document.getElementById('wash-list').after(form);
             form.classList.add('hidden');
@@ -467,6 +503,7 @@
             const washerSelect = form.querySelector('select[name="temp_washer_id"]');
             washerSelect.value = wrapper.querySelector(`input[name="washes[${index}][washer_id]"]`).value;
             if(washerSelect._searchInput){ washerSelect._searchInput.value = washerSelect.options[washerSelect.selectedIndex]?.text || ''; }
+            form.querySelector('input[name="temp_tip"]').value = wrapper.querySelector(`input[name="washes[${index}][tip]"]`).value;
             form.querySelectorAll('input[name="temp_service_ids[]"]').forEach(cb=>{
                 const val = cb.value;
                 cb.checked = wrapper.querySelector(`input[name="washes[${index}][service_ids][]"][value="${val}"]`) !== null;
@@ -681,8 +718,12 @@
                     const hasWash = form.querySelectorAll('.wash-item').length > 0;
                     const hasProduct = Array.from(form.querySelectorAll('#product-list select[name="product_ids[]"]')).some(s => s.value);
                     const hasDrink = Array.from(form.querySelectorAll('#drink-list select[name="drink_ids[]"]')).some(s => s.value);
-                    if (!hasWash && !hasProduct && !hasDrink) {
-                        this.errors.push('Debe agregar al menos un servicio, producto o trago');
+                    const hasCharge = Array.from(form.querySelectorAll('#charge-list input[name="charge_descriptions[]"]')).some((input,idx) => {
+                        const amount = parseFloat(form.querySelectorAll('#charge-list input[name="charge_amounts[]"]')[idx].value || 0);
+                        return input.value.trim() !== '' && amount > 0;
+                    });
+                    if (!hasWash && !hasProduct && !hasDrink && !hasCharge) {
+                        this.errors.push('Debe agregar al menos un servicio, producto, trago o cargo adicional');
                         this.showErrors();
                         return;
                     }

--- a/resources/views/tickets/partials/canceled-table.blade.php
+++ b/resources/views/tickets/partials/canceled-table.blade.php
@@ -19,7 +19,7 @@
                     <td class="px-4 py-2">{{ $ticket->customer_name }}</td>
                     <td class="px-4 py-2">
                         {{ $ticket->details->pluck('type')->unique()->map(fn($t) => match($t){
-                            'service' => 'Lavado', 'product' => 'Productos', 'drink' => 'Tragos'
+                            'service' => 'Lavado', 'product' => 'Productos', 'drink' => 'Tragos', 'extra' => 'Cargos'
                         })->implode(', ') }}
                     </td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->discount_total, 2) }}</td>
@@ -62,7 +62,8 @@
                             {{ match($d->type){
                                 'service' => $d->service->name ?? 'Servicio',
                                 'product' => $d->product->name ?? 'Producto',
-                                'drink' => $d->drink->name ?? 'Trago'
+                                'drink' => $d->drink->name ?? 'Trago',
+                                'extra' => $d->description ?? 'Cargo'
                             } }} x{{ $d->quantity }} - RD$ {{ number_format($d->unit_price,2) }}
                         </li>
                     @endforeach

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -59,27 +59,12 @@
             @endphp
             @if($hasCommission || $hasTip)
             <div class="space-y-2 text-sm">
-                <p class="font-medium">¿Desea pagar al lavador de todos modos?</p>
-                @if($hasCommission)
-                <div>
-                    <label class="block">Comisión</label>
-                    <select name="pay_commission" class="form-select w-full" {{ $hasTip ? '' : 'required' }}>
-                        <option value=""></option>
-                        <option value="yes">Si</option>
-                        <option value="no">No</option>
-                    </select>
-                </div>
-                @endif
-                @if($hasTip)
-                <div>
-                    <label class="block">Propina</label>
-                    <select name="pay_tip" class="form-select w-full" {{ $hasCommission ? '' : 'required' }}>
-                        <option value=""></option>
-                        <option value="yes">Si</option>
-                        <option value="no">No</option>
-                    </select>
-                </div>
-                @endif
+                <label class="block font-medium">¿Desea pagar la comisión o propina al lavador de todos modos?</label>
+                <select name="pay_washer" class="form-select w-full" required>
+                    <option value=""></option>
+                    <option value="yes">Si</option>
+                    <option value="no">No</option>
+                </select>
             </div>
             @endif
             <div class="flex justify-end">

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -54,19 +54,31 @@
                 <input type="text" name="cancel_reason" class="form-input w-full" required>
             </div>
             @php
-                $hasPaidCommission = $ticket->washes->where('washer_paid', true)->isNotEmpty();
-                $hasPaidTip = \App\Models\WasherMovement::where('ticket_id', $ticket->id)
-                    ->where('description', 'like', '[P]%')
-                    ->where('paid', true)
-                    ->exists();
+                $hasCommission = $ticket->washes->whereNotNull('washer_id')->isNotEmpty();
+                $hasTip = $ticket->washes->sum('tip') > 0;
             @endphp
-            @if($hasPaidCommission || $hasPaidTip)
+            @if($hasCommission || $hasTip)
             <div class="space-y-2 text-sm">
-                @if($hasPaidCommission)
-                <label class="inline-flex items-center"><input type="checkbox" name="pay_commission" value="1" class="mr-1"> Mantener comisiones pagadas</label>
+                <p class="font-medium">¿Desea pagar al lavador de todos modos?</p>
+                @if($hasCommission)
+                <div>
+                    <label class="block">Comisión</label>
+                    <select name="pay_commission" class="form-select w-full" {{ $hasTip ? '' : 'required' }}>
+                        <option value=""></option>
+                        <option value="yes">Si</option>
+                        <option value="no">No</option>
+                    </select>
+                </div>
                 @endif
-                @if($hasPaidTip)
-                <label class="inline-flex items-center"><input type="checkbox" name="pay_tip" value="1" class="mr-1"> Mantener propinas pagadas</label>
+                @if($hasTip)
+                <div>
+                    <label class="block">Propina</label>
+                    <select name="pay_tip" class="form-select w-full" {{ $hasCommission ? '' : 'required' }}>
+                        <option value=""></option>
+                        <option value="yes">Si</option>
+                        <option value="no">No</option>
+                    </select>
+                </div>
                 @endif
             </div>
             @endif

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -30,7 +30,7 @@
                     <td class="px-4 py-2">{{ $ticket->customer_name }}</td>
                     <td class="px-4 py-2">
                         {{ $ticket->details->pluck('type')->unique()->map(fn($t) => match($t){
-                            'service' => 'Lavado', 'product' => 'Productos', 'drink' => 'Tragos'
+                            'service' => 'Lavado', 'product' => 'Productos', 'drink' => 'Tragos', 'extra' => 'Cargos'
                         })->implode(', ') }}
                     </td>
                     <td class="px-4 py-2">RD$ {{ number_format($ticket->discount_total, 2) }}</td>
@@ -127,7 +127,8 @@
                             {{ match($d->type){
                                 'service' => $d->service->name ?? 'Servicio',
                                 'product' => $d->product->name ?? 'Producto',
-                                'drink' => $d->drink->name ?? 'Trago'
+                                'drink' => $d->drink->name ?? 'Trago',
+                                'extra' => $d->description ?? 'Cargo'
                             } }} x{{ $d->quantity }} - RD$ {{ number_format($d->unit_price,2) }}
                         </li>
                     @endforeach
@@ -143,6 +144,9 @@
                         <div class="border rounded p-2">
                             <p class="text-sm font-semibold">{{ $wash->vehicle->brand }} | {{ $wash->vehicle->model }} | {{ $wash->vehicle->color }} | {{ $wash->vehicle->year }} | {{ $wash->vehicleType->name }}</p>
                             <p class="text-sm">Servicios: {{ $wash->details->where('type','service')->map(fn($d)=>$d->service->name)->implode(', ') }}</p>
+                            @if($wash->tip > 0)
+                                <p class="text-sm">Propina: RD$ {{ number_format($wash->tip,2) }}</p>
+                            @endif
                             <div class="mt-1">
                                 <label class="block text-sm font-medium text-gray-700">Lavador</label>
                                 <select name="washers[{{ $wash->id }}]" class="form-select w-full">

--- a/resources/views/washers/partials/ledger.blade.php
+++ b/resources/views/washers/partials/ledger.blade.php
@@ -14,7 +14,7 @@
         </thead>
         <tbody>
             @foreach($events as $e)
-                <tr class="border-b">
+                <tr class="border-b {{ ($e['canceled'] ?? false) ? 'bg-red-100' : '' }}">
                     <td class="px-4 py-2 text-center">
                         @if(!is_null($e['gain']) && $e['gain'] > 0 && !($e['paid_to_washer'] ?? false))
                             <input type="checkbox" class="gain-check" data-amount="{{ $e['gain'] }}"

--- a/resources/views/washers/partials/ledger.blade.php
+++ b/resources/views/washers/partials/ledger.blade.php
@@ -16,8 +16,10 @@
             @foreach($events as $e)
                 <tr class="border-b">
                     <td class="px-4 py-2 text-center">
-                        @if(!is_null($e['gain']) && $e['gain'] > 0 && ($e['wash_id'] ?? false) && !($e['paid_to_washer'] ?? false))
-                            <input type="checkbox" class="gain-check" data-amount="{{ $e['gain'] }}" data-wash="{{ $e['wash_id'] }}">
+                        @if(!is_null($e['gain']) && $e['gain'] > 0 && !($e['paid_to_washer'] ?? false))
+                            <input type="checkbox" class="gain-check" data-amount="{{ $e['gain'] }}"
+                                @if($e['wash_id'] ?? false) data-wash="{{ $e['wash_id'] }}" @endif
+                                @if($e['movement_id'] ?? false) data-movement="{{ $e['movement_id'] }}" @endif>
                         @endif
                     </td>
                     <td class="px-4 py-2">{{ \Carbon\Carbon::parse($e['date'])->format('d/m/Y h:i A') }}</td>

--- a/resources/views/washers/show.blade.php
+++ b/resources/views/washers/show.blade.php
@@ -58,6 +58,7 @@
             <input type="hidden" name="amount" value="0">
             <input type="hidden" name="total_washes" value="0">
             <input type="hidden" name="wash_ids" value="">
+            <input type="hidden" name="movement_ids" value="">
             <h2 class="text-lg font-medium text-gray-900">Confirmar pago</h2>
             <p class="text-sm text-gray-600">Se pagará a <strong>{{ $washer->name }}</strong> RD$ <span class="selected-amount">0.00</span>.</p>
             <div class="mt-6 flex justify-end">
@@ -87,15 +88,18 @@ function preparePayment(id) {
         return;
     }
     let total = 0;
-    const ids = [];
+    const washIds = [];
+    const movementIds = [];
     checks.forEach(c => {
         total += parseFloat(c.dataset.amount);
-        ids.push(c.dataset.wash);
+        if (c.dataset.wash) washIds.push(c.dataset.wash);
+        if (c.dataset.movement) movementIds.push(c.dataset.movement);
     });
     const form = document.getElementById(`pay-washer-form-${id}`);
     form.querySelector('input[name="amount"]').value = total.toFixed(2);
-    form.querySelector('input[name="total_washes"]').value = checks.length;
-    form.querySelector('input[name="wash_ids"]').value = ids.join(',');
+    form.querySelector('input[name="total_washes"]').value = washIds.length;
+    form.querySelector('input[name="wash_ids"]').value = washIds.join(',');
+    form.querySelector('input[name="movement_ids"]').value = movementIds.join(',');
     form.querySelector('.selected-amount').textContent = total.toFixed(2);
     window.dispatchEvent(new CustomEvent('open-modal', { detail: `pay-washer-${id}` }));
 }

--- a/tests/Feature/DashboardWasherPayDuePaidTest.php
+++ b/tests/Feature/DashboardWasherPayDuePaidTest.php
@@ -6,30 +6,23 @@ use App\Models\Washer;
 use App\Models\Service;
 use App\Models\VehicleType;
 use App\Models\Ticket;
-use App\Models\TicketDetail;
-use App\Models\WasherPayment;
-use App\Models\WasherMovement;
 use App\Models\TicketWash;
+use App\Models\TicketDetail;
+use App\Models\WasherMovement;
+use App\Models\WasherPayment;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Carbon\Carbon;
 
-class WasherDebtTest extends TestCase
+class DashboardWasherPayDuePaidTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_cancel_paid_ticket_creates_washer_debt(): void
+    public function test_washer_pay_due_after_payment_is_zero(): void
     {
         Carbon::setTestNow(Carbon::parse('2024-01-01 10:00:00'));
-
         $user = User::factory()->create(['role' => 'admin']);
-
-        $washer = Washer::create([
-            'name' => 'Lavador',
-            'pending_amount' => 0,
-            'active' => true,
-        ]);
-
+        $washer = Washer::create(['name' => 'Lavador', 'pending_amount' => 0, 'active' => true]);
         $vehicleType = VehicleType::create(['name' => 'Car']);
         $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
 
@@ -39,8 +32,8 @@ class WasherDebtTest extends TestCase
             'vehicle_id' => null,
             'customer_name' => 'Cliente',
             'customer_cedula' => null,
-            'total_amount' => 200,
-            'paid_amount' => 200,
+            'total_amount' => 0,
+            'paid_amount' => 0,
             'change' => 0,
             'discount_total' => 0,
             'payment_method' => 'efectivo',
@@ -58,7 +51,7 @@ class WasherDebtTest extends TestCase
             'vehicle_id' => null,
             'vehicle_type_id' => $vehicleType->id,
             'washer_paid' => false,
-            'tip' => 0,
+            'tip' => 10,
         ]);
 
         TicketDetail::create([
@@ -69,38 +62,33 @@ class WasherDebtTest extends TestCase
             'product_id' => null,
             'drink_id' => null,
             'quantity' => 1,
-            'unit_price' => 200,
+            'unit_price' => 0,
             'discount_amount' => 0,
-            'subtotal' => 200,
+            'subtotal' => 0,
         ]);
 
-        $washer->increment('pending_amount', 100);
+        $movement = WasherMovement::create([
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 10,
+            'description' => '[P] Test',
+            'created_at' => now(),
+        ]);
+        $washer->increment('pending_amount', 110);
+
         WasherPayment::create([
             'washer_id' => $washer->id,
             'payment_date' => now(),
             'total_washes' => 1,
-            'amount_paid' => 100,
+            'amount_paid' => 110,
+            'created_at' => now(),
         ]);
-        $washer->update(['pending_amount' => 0]);
         $wash->update(['washer_paid' => true]);
+        $movement->update(['paid' => true]);
+        $washer->update(['pending_amount' => 0]);
 
-        $this->actingAs($user)
-            ->post(route('tickets.cancel', $ticket), ['cancel_reason' => 'test']);
-
-        $this->assertDatabaseHas('washer_movements', [
-            'washer_id' => $washer->id,
-            'ticket_id' => $ticket->id,
-            'amount' => -100,
-            'description' => 'Cuenta por cobrar - Ganancia de ticket cancelado',
-        ]);
-
-        $response = $this->actingAs($user)
-            ->get('/dashboard?start=' . now()->toDateString() . '&end=' . now()->toDateString());
-        $this->assertEquals(100, $response->viewData('accountsReceivable'));
-
-        $response = $this->actingAs($user)
-            ->get('/dashboard?start=' . now()->addDay()->toDateString() . '&end=' . now()->addDay()->toDateString());
-        $this->assertEquals(0, $response->viewData('accountsReceivable'));
+        $response = $this->actingAs($user)->get('/dashboard?start=2024-01-01&end=2024-01-01');
+        $this->assertEquals(0, $response->viewData('washerPayDue'));
 
         Carbon::setTestNow();
     }

--- a/tests/Feature/TicketCancelKeepPaymentsTest.php
+++ b/tests/Feature/TicketCancelKeepPaymentsTest.php
@@ -6,30 +6,23 @@ use App\Models\Washer;
 use App\Models\Service;
 use App\Models\VehicleType;
 use App\Models\Ticket;
-use App\Models\TicketDetail;
-use App\Models\WasherPayment;
-use App\Models\WasherMovement;
 use App\Models\TicketWash;
+use App\Models\TicketDetail;
+use App\Models\WasherMovement;
+use App\Models\WasherPayment;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Carbon\Carbon;
 
-class WasherDebtTest extends TestCase
+class TicketCancelKeepPaymentsTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_cancel_paid_ticket_creates_washer_debt(): void
+    public function test_cancel_paid_ticket_keeps_payments_when_requested(): void
     {
         Carbon::setTestNow(Carbon::parse('2024-01-01 10:00:00'));
-
         $user = User::factory()->create(['role' => 'admin']);
-
-        $washer = Washer::create([
-            'name' => 'Lavador',
-            'pending_amount' => 0,
-            'active' => true,
-        ]);
-
+        $washer = Washer::create(['name' => 'Lavador', 'pending_amount' => 0, 'active' => true]);
         $vehicleType = VehicleType::create(['name' => 'Car']);
         $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
 
@@ -39,8 +32,8 @@ class WasherDebtTest extends TestCase
             'vehicle_id' => null,
             'customer_name' => 'Cliente',
             'customer_cedula' => null,
-            'total_amount' => 200,
-            'paid_amount' => 200,
+            'total_amount' => 0,
+            'paid_amount' => 0,
             'change' => 0,
             'discount_total' => 0,
             'payment_method' => 'efectivo',
@@ -57,8 +50,8 @@ class WasherDebtTest extends TestCase
             'washer_id' => $washer->id,
             'vehicle_id' => null,
             'vehicle_type_id' => $vehicleType->id,
-            'washer_paid' => false,
-            'tip' => 0,
+            'washer_paid' => true,
+            'tip' => 15,
         ]);
 
         TicketDetail::create([
@@ -69,38 +62,53 @@ class WasherDebtTest extends TestCase
             'product_id' => null,
             'drink_id' => null,
             'quantity' => 1,
-            'unit_price' => 200,
+            'unit_price' => 0,
             'discount_amount' => 0,
-            'subtotal' => 200,
+            'subtotal' => 0,
         ]);
 
-        $washer->increment('pending_amount', 100);
+        $movement = WasherMovement::create([
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 15,
+            'description' => '[P] Test',
+            'paid' => true,
+            'created_at' => now(),
+        ]);
         WasherPayment::create([
             'washer_id' => $washer->id,
             'payment_date' => now(),
             'total_washes' => 1,
-            'amount_paid' => 100,
+            'amount_paid' => 115,
+            'created_at' => now(),
         ]);
-        $washer->update(['pending_amount' => 0]);
-        $wash->update(['washer_paid' => true]);
 
-        $this->actingAs($user)
-            ->post(route('tickets.cancel', $ticket), ['cancel_reason' => 'test']);
+        $response = $this->actingAs($user)->post(route('tickets.cancel', $ticket), [
+            'cancel_reason' => 'test',
+            'pay_commission' => 1,
+            'pay_tip' => 1,
+        ]);
 
+        $washer->refresh();
+        $this->assertEquals(0, $washer->pending_amount);
         $this->assertDatabaseHas('washer_movements', [
             'washer_id' => $washer->id,
             'ticket_id' => $ticket->id,
-            'amount' => -100,
+            'amount' => 15,
+            'description' => '[P] Test',
+            'paid' => true,
+        ]);
+        $this->assertDatabaseMissing('washer_movements', [
             'description' => 'Cuenta por cobrar - Ganancia de ticket cancelado',
+            'ticket_id' => $ticket->id,
+        ]);
+        $this->assertDatabaseMissing('washer_movements', [
+            'description' => 'Cuenta por cobrar - Propina de ticket cancelado',
+            'ticket_id' => $ticket->id,
         ]);
 
-        $response = $this->actingAs($user)
-            ->get('/dashboard?start=' . now()->toDateString() . '&end=' . now()->toDateString());
-        $this->assertEquals(100, $response->viewData('accountsReceivable'));
-
-        $response = $this->actingAs($user)
-            ->get('/dashboard?start=' . now()->addDay()->toDateString() . '&end=' . now()->addDay()->toDateString());
-        $this->assertEquals(0, $response->viewData('accountsReceivable'));
+        $dash = $this->actingAs($user)->get('/dashboard?start=2024-01-01&end=2024-01-01');
+        $this->assertEquals(0, $dash->viewData('accountsReceivable'));
 
         Carbon::setTestNow();
     }

--- a/tests/Feature/TicketCancelKeepPaymentsTest.php
+++ b/tests/Feature/TicketCancelKeepPaymentsTest.php
@@ -85,8 +85,7 @@ class TicketCancelKeepPaymentsTest extends TestCase
 
         $response = $this->actingAs($user)->post(route('tickets.cancel', $ticket), [
             'cancel_reason' => 'test',
-            'pay_commission' => 'yes',
-            'pay_tip' => 'yes',
+            'pay_washer' => 'yes',
         ]);
 
         $washer->refresh();
@@ -118,6 +117,7 @@ class TicketCancelKeepPaymentsTest extends TestCase
 
         $dash = $this->actingAs($user)->get('/dashboard?start=2024-01-01&end=2024-01-01');
         $this->assertEquals(0, $dash->viewData('accountsReceivable'));
+        $this->assertEquals(-115, $dash->viewData('grossProfit'));
 
         Carbon::setTestNow();
     }

--- a/tests/Feature/TicketCancelKeepPaymentsTest.php
+++ b/tests/Feature/TicketCancelKeepPaymentsTest.php
@@ -85,8 +85,8 @@ class TicketCancelKeepPaymentsTest extends TestCase
 
         $response = $this->actingAs($user)->post(route('tickets.cancel', $ticket), [
             'cancel_reason' => 'test',
-            'pay_commission' => 1,
-            'pay_tip' => 1,
+            'pay_commission' => 'yes',
+            'pay_tip' => 'yes',
         ]);
 
         $washer->refresh();
@@ -105,6 +105,15 @@ class TicketCancelKeepPaymentsTest extends TestCase
         $this->assertDatabaseMissing('washer_movements', [
             'description' => 'Cuenta por cobrar - Propina de ticket cancelado',
             'ticket_id' => $ticket->id,
+        ]);
+        $this->assertDatabaseHas('tickets', [
+            'id' => $ticket->id,
+            'keep_commission_on_cancel' => true,
+            'keep_tip_on_cancel' => true,
+        ]);
+        $this->assertDatabaseHas('washer_payments', [
+            'washer_id' => $washer->id,
+            'canceled_ticket' => true,
         ]);
 
         $dash = $this->actingAs($user)->get('/dashboard?start=2024-01-01&end=2024-01-01');

--- a/tests/Feature/TicketCancelKeepPaymentsTest.php
+++ b/tests/Feature/TicketCancelKeepPaymentsTest.php
@@ -121,4 +121,82 @@ class TicketCancelKeepPaymentsTest extends TestCase
 
         Carbon::setTestNow();
     }
+
+    public function test_cancel_after_payment_preserves_original_payment_date(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2024-01-01 10:00:00'));
+        $user = User::factory()->create(['role' => 'admin']);
+        $washer = Washer::create(['name' => 'Lavador', 'pending_amount' => 0, 'active' => true]);
+        $vehicleType = VehicleType::create(['name' => 'Car']);
+        $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
+
+        $ticket = Ticket::create([
+            'user_id' => $user->id,
+            'vehicle_type_id' => $vehicleType->id,
+            'vehicle_id' => null,
+            'customer_name' => 'Cliente',
+            'customer_cedula' => null,
+            'total_amount' => 0,
+            'paid_amount' => 0,
+            'change' => 0,
+            'discount_total' => 0,
+            'payment_method' => 'efectivo',
+            'bank_account_id' => null,
+            'washer_pending_amount' => 0,
+            'canceled' => false,
+            'cancel_reason' => null,
+            'pending' => false,
+            'paid_at' => now(),
+        ]);
+
+        $wash = TicketWash::create([
+            'ticket_id' => $ticket->id,
+            'washer_id' => $washer->id,
+            'vehicle_id' => null,
+            'vehicle_type_id' => $vehicleType->id,
+            'washer_paid' => true,
+            'tip' => 15,
+        ]);
+
+        TicketDetail::create([
+            'ticket_id' => $ticket->id,
+            'ticket_wash_id' => $wash->id,
+            'type' => 'service',
+            'service_id' => $service->id,
+            'product_id' => null,
+            'drink_id' => null,
+            'quantity' => 1,
+            'unit_price' => 0,
+            'discount_amount' => 0,
+            'subtotal' => 0,
+        ]);
+
+        WasherMovement::create([
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 15,
+            'description' => '[P] Test',
+            'paid' => true,
+            'created_at' => now(),
+        ]);
+        WasherPayment::create([
+            'washer_id' => $washer->id,
+            'payment_date' => now(),
+            'total_washes' => 1,
+            'amount_paid' => 115,
+            'created_at' => now(),
+        ]);
+
+        Carbon::setTestNow(Carbon::parse('2024-01-05 12:00:00'));
+
+        $this->actingAs($user)->post(route('tickets.cancel', $ticket), [
+            'cancel_reason' => 'test',
+            'pay_washer' => 'yes',
+        ]);
+
+        $payment = WasherPayment::first();
+        $this->assertEquals('2024-01-01', Carbon::parse($payment->payment_date)->toDateString());
+
+        Carbon::setTestNow();
+    }
 }

--- a/tests/Feature/TicketCancelRecoverPaymentsTest.php
+++ b/tests/Feature/TicketCancelRecoverPaymentsTest.php
@@ -6,30 +6,23 @@ use App\Models\Washer;
 use App\Models\Service;
 use App\Models\VehicleType;
 use App\Models\Ticket;
-use App\Models\TicketDetail;
-use App\Models\WasherPayment;
-use App\Models\WasherMovement;
 use App\Models\TicketWash;
+use App\Models\TicketDetail;
+use App\Models\WasherMovement;
+use App\Models\WasherPayment;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Carbon\Carbon;
 
-class WasherDebtTest extends TestCase
+class TicketCancelRecoverPaymentsTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_cancel_paid_ticket_creates_washer_debt(): void
+    public function test_cancel_paid_ticket_creates_receivable_when_not_paying(): void
     {
-        Carbon::setTestNow(Carbon::parse('2024-01-01 10:00:00'));
-
+        Carbon::setTestNow(Carbon::parse('2024-02-01 10:00:00'));
         $user = User::factory()->create(['role' => 'admin']);
-
-        $washer = Washer::create([
-            'name' => 'Lavador',
-            'pending_amount' => 0,
-            'active' => true,
-        ]);
-
+        $washer = Washer::create(['name' => 'Lavador', 'pending_amount' => 0, 'active' => true]);
         $vehicleType = VehicleType::create(['name' => 'Car']);
         $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
 
@@ -39,8 +32,8 @@ class WasherDebtTest extends TestCase
             'vehicle_id' => null,
             'customer_name' => 'Cliente',
             'customer_cedula' => null,
-            'total_amount' => 200,
-            'paid_amount' => 200,
+            'total_amount' => 0,
+            'paid_amount' => 0,
             'change' => 0,
             'discount_total' => 0,
             'payment_method' => 'efectivo',
@@ -57,8 +50,8 @@ class WasherDebtTest extends TestCase
             'washer_id' => $washer->id,
             'vehicle_id' => null,
             'vehicle_type_id' => $vehicleType->id,
-            'washer_paid' => false,
-            'tip' => 0,
+            'washer_paid' => true,
+            'tip' => 20,
         ]);
 
         TicketDetail::create([
@@ -69,26 +62,32 @@ class WasherDebtTest extends TestCase
             'product_id' => null,
             'drink_id' => null,
             'quantity' => 1,
-            'unit_price' => 200,
+            'unit_price' => 0,
             'discount_amount' => 0,
-            'subtotal' => 200,
+            'subtotal' => 0,
         ]);
 
-        $washer->increment('pending_amount', 100);
+        $movement = WasherMovement::create([
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 20,
+            'description' => '[P] Test',
+            'paid' => true,
+            'created_at' => now(),
+        ]);
         WasherPayment::create([
             'washer_id' => $washer->id,
             'payment_date' => now(),
             'total_washes' => 1,
-            'amount_paid' => 100,
+            'amount_paid' => 120,
+            'created_at' => now(),
         ]);
-        $washer->update(['pending_amount' => 0]);
-        $wash->update(['washer_paid' => true]);
 
-        $this->actingAs($user)
-            ->post(route('tickets.cancel', $ticket), [
-                'cancel_reason' => 'test',
-                'pay_commission' => 'no',
-            ]);
+        $this->actingAs($user)->post(route('tickets.cancel', $ticket), [
+            'cancel_reason' => 'test',
+            'pay_commission' => 'no',
+            'pay_tip' => 'no',
+        ]);
 
         $this->assertDatabaseHas('washer_movements', [
             'washer_id' => $washer->id,
@@ -96,15 +95,28 @@ class WasherDebtTest extends TestCase
             'amount' => -100,
             'description' => 'Cuenta por cobrar - Ganancia de ticket cancelado',
         ]);
-
-        $response = $this->actingAs($user)
-            ->get('/dashboard?start=' . now()->toDateString() . '&end=' . now()->toDateString());
-        $this->assertEquals(100, $response->viewData('accountsReceivable'));
-
-        $response = $this->actingAs($user)
-            ->get('/dashboard?start=' . now()->addDay()->toDateString() . '&end=' . now()->addDay()->toDateString());
-        $this->assertEquals(0, $response->viewData('accountsReceivable'));
-
+        $this->assertDatabaseHas('washer_movements', [
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => -20,
+            'description' => 'Cuenta por cobrar - Propina de ticket cancelado',
+        ]);
+        $this->assertDatabaseHas('washer_movements', [
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 20,
+            'description' => '[P] Test',
+            'paid' => true,
+        ]);
+        $this->assertDatabaseHas('washer_payments', [
+            'washer_id' => $washer->id,
+            'canceled_ticket' => false,
+        ]);
+        $this->assertDatabaseHas('tickets', [
+            'id' => $ticket->id,
+            'keep_commission_on_cancel' => false,
+            'keep_tip_on_cancel' => false,
+        ]);
         Carbon::setTestNow();
     }
 }

--- a/tests/Feature/TicketCancelRecoverPaymentsTest.php
+++ b/tests/Feature/TicketCancelRecoverPaymentsTest.php
@@ -85,8 +85,7 @@ class TicketCancelRecoverPaymentsTest extends TestCase
 
         $this->actingAs($user)->post(route('tickets.cancel', $ticket), [
             'cancel_reason' => 'test',
-            'pay_commission' => 'no',
-            'pay_tip' => 'no',
+            'pay_washer' => 'no',
         ]);
 
         $this->assertDatabaseHas('washer_movements', [

--- a/tests/Feature/TicketCancelTipTest.php
+++ b/tests/Feature/TicketCancelTipTest.php
@@ -61,8 +61,7 @@ class TicketCancelTipTest extends TestCase
 
         $this->actingAs($user)->post(route('tickets.cancel', $ticket), [
             'cancel_reason' => 'test',
-            'pay_commission' => 'no',
-            'pay_tip' => 'no',
+            'pay_washer' => 'no',
         ]);
 
         $washer->refresh();

--- a/tests/Feature/TicketCancelTipTest.php
+++ b/tests/Feature/TicketCancelTipTest.php
@@ -59,7 +59,11 @@ class TicketCancelTipTest extends TestCase
         ]);
         $washer->increment('pending_amount', 130);
 
-        $this->actingAs($user)->post(route('tickets.cancel', $ticket), ['cancel_reason' => 'test']);
+        $this->actingAs($user)->post(route('tickets.cancel', $ticket), [
+            'cancel_reason' => 'test',
+            'pay_commission' => 'no',
+            'pay_tip' => 'no',
+        ]);
 
         $washer->refresh();
         $this->assertEquals(0, $washer->pending_amount);

--- a/tests/Feature/TicketCancelTipTest.php
+++ b/tests/Feature/TicketCancelTipTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Washer;
+use App\Models\Ticket;
+use App\Models\TicketWash;
+use App\Models\WasherMovement;
+
+class TicketCancelTipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cancel_removes_tip_from_washer()
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $washer = Washer::create(['name' => 'W', 'pending_amount' => 0, 'active' => true]);
+
+        $ticket = Ticket::create([
+            'user_id' => $user->id,
+            'total_amount' => 0,
+            'paid_amount' => 0,
+            'payment_method' => 'efectivo',
+            'washer_pending_amount' => 0,
+            'customer_name' => 'Cliente',
+            'pending' => false,
+            'canceled' => false,
+        ]);
+
+        $wash = TicketWash::create([
+            'ticket_id' => $ticket->id,
+            'washer_id' => $washer->id,
+            'vehicle_id' => null,
+            'vehicle_type_id' => null,
+            'washer_paid' => false,
+            'tip' => 30,
+        ]);
+        \App\Models\TicketDetail::create([
+            'ticket_id' => $ticket->id,
+            'ticket_wash_id' => $wash->id,
+            'type' => 'service',
+            'service_id' => null,
+            'product_id' => null,
+            'drink_id' => null,
+            'quantity' => 1,
+            'unit_price' => 0,
+            'discount_amount' => 0,
+            'subtotal' => 0,
+        ]);
+
+        WasherMovement::create([
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 30,
+            'description' => '[P] Test',
+        ]);
+        $washer->increment('pending_amount', 130);
+
+        $this->actingAs($user)->post(route('tickets.cancel', $ticket), ['cancel_reason' => 'test']);
+
+        $washer->refresh();
+        $this->assertEquals(0, $washer->pending_amount);
+        $this->assertDatabaseMissing('washer_movements', [
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 30,
+        ]);
+    }
+}

--- a/tests/Feature/TicketEditTipExtraTest.php
+++ b/tests/Feature/TicketEditTipExtraTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Washer;
+use App\Models\Service;
+use App\Models\ServicePrice;
+use App\Models\VehicleType;
+use App\Models\WasherMovement;
+use App\Models\Ticket;
+use App\Models\TicketWash;
+use App\Models\TicketDetail;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class TicketEditTipExtraTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_edit_ticket_updates_tip_and_extra_and_sets_tip_date(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $this->actingAs($user);
+
+        $vehicleType = VehicleType::create(['name' => 'Carro']);
+        $washer = Washer::create(['name' => 'Juan', 'pending_amount' => 0, 'active' => true]);
+        $service = Service::create(['name' => 'Lavado', 'description' => 'test', 'active' => true]);
+        ServicePrice::create(['service_id' => $service->id, 'vehicle_type_id' => $vehicleType->id, 'price' => 200]);
+
+        $date = Carbon::parse('2024-01-10');
+
+        $vehicle = Vehicle::create([
+            'customer_name' => 'Cliente',
+            'vehicle_type_id' => $vehicleType->id,
+            'plate' => 'ABC123',
+            'brand' => 'Toyota',
+            'model' => 'Corolla',
+            'color' => 'Rojo',
+            'year' => 2020,
+        ]);
+
+        $ticket = Ticket::create([
+            'user_id' => $user->id,
+            'customer_name' => 'Cliente',
+            'customer_phone' => null,
+            'total_amount' => 230,
+            'paid_amount' => 0,
+            'change' => 0,
+            'discount_total' => 0,
+            'payment_method' => 'efectivo',
+            'bank_account_id' => null,
+            'washer_pending_amount' => 0,
+            'pending' => true,
+            'paid_at' => null,
+            'created_at' => $date,
+        ]);
+
+        $wash = TicketWash::create([
+            'ticket_id' => $ticket->id,
+            'vehicle_id' => $vehicle->id,
+            'vehicle_type_id' => $vehicleType->id,
+            'washer_id' => $washer->id,
+            'washer_paid' => false,
+            'tip' => 20,
+        ]);
+
+        TicketDetail::create([
+            'ticket_id' => $ticket->id,
+            'ticket_wash_id' => $wash->id,
+            'type' => 'service',
+            'service_id' => $service->id,
+            'product_id' => null,
+            'drink_id' => null,
+            'quantity' => 1,
+            'unit_price' => 200,
+            'discount_amount' => 0,
+            'subtotal' => 200,
+        ]);
+
+        TicketDetail::create([
+            'ticket_id' => $ticket->id,
+            'ticket_wash_id' => null,
+            'type' => 'extra',
+            'service_id' => null,
+            'product_id' => null,
+            'drink_id' => null,
+            'quantity' => 1,
+            'unit_price' => 10,
+            'discount_amount' => 0,
+            'subtotal' => 10,
+            'description' => 'Cargo',
+        ]);
+
+        Washer::whereId($washer->id)->increment('pending_amount', 120);
+        WasherMovement::create([
+            'washer_id' => $washer->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 20,
+            'description' => '[P] Toyota | Corolla | Rojo | 2020 | Carro',
+            'created_at' => $date,
+            'updated_at' => $date,
+        ]);
+
+        $updateData = [
+            'customer_name' => 'Cliente',
+            'customer_phone' => null,
+            'ticket_date' => $date->format('Y-m-d'),
+            'washes' => [
+                [
+                    'vehicle_type_id' => $vehicleType->id,
+                    'plate' => 'ABC123',
+                    'brand' => 'Toyota',
+                    'model' => 'Corolla',
+                    'color' => 'Rojo',
+                    'year' => 2020,
+                    'washer_id' => $washer->id,
+                    'service_ids' => [$service->id],
+                    'tip' => 30,
+                ],
+            ],
+            'charge_descriptions' => ['Cargo'],
+            'charge_amounts' => [15],
+            'ticket_action' => 'pay',
+            'payment_method' => 'efectivo',
+            'paid_amount' => 245,
+            'bank_account_id' => null,
+        ];
+
+        $response = $this->put(route('tickets.update', $ticket), $updateData);
+        $response->assertSessionHasNoErrors();
+        $ticket->refresh();
+
+        $this->assertEquals(200 + 30 + 15, $ticket->total_amount);
+        $this->assertDatabaseHas('ticket_details', ['ticket_id' => $ticket->id, 'type' => 'extra', 'unit_price' => 15]);
+        $this->assertDatabaseHas('ticket_washes', ['ticket_id' => $ticket->id, 'tip' => 30]);
+
+        $washer->refresh();
+        $this->assertEquals(100 + 30, $washer->pending_amount);
+        $this->assertEquals(1, WasherMovement::where('washer_id', $washer->id)->where('ticket_id', $ticket->id)->where('description', 'like', '[P]%')->count());
+        $movement = WasherMovement::where('washer_id', $washer->id)->where('ticket_id', $ticket->id)->first();
+        $this->assertEquals(30, $movement->amount);
+        $this->assertTrue($movement->created_at->isSameDay($date));
+    }
+}
+

--- a/tests/Feature/TicketExtraChargeTest.php
+++ b/tests/Feature/TicketExtraChargeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Ticket;
+use App\Models\TicketDetail;
+use App\Models\VehicleType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class TicketExtraChargeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ticket_with_extra_charge_is_persisted(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $vehicleType = VehicleType::create(['name' => 'Carro']);
+        $date = Carbon::today();
+
+        $ticket = Ticket::create([
+            'user_id' => $user->id,
+            'washer_id' => null,
+            'vehicle_type_id' => $vehicleType->id,
+            'vehicle_id' => null,
+            'customer_name' => 'Cliente',
+            'customer_cedula' => null,
+            'customer_phone' => null,
+            'total_amount' => 50,
+            'paid_amount' => 50,
+            'change' => 0,
+            'discount_total' => 0,
+            'payment_method' => 'efectivo',
+            'bank_account_id' => null,
+            'washer_pending_amount' => 0,
+            'canceled' => false,
+            'cancel_reason' => null,
+            'pending' => false,
+            'paid_at' => $date,
+        ]);
+
+        TicketDetail::create([
+            'ticket_id' => $ticket->id,
+            'type' => 'extra',
+            'service_id' => null,
+            'product_id' => null,
+            'drink_id' => null,
+            'quantity' => 1,
+            'unit_price' => 50,
+            'discount_amount' => 0,
+            'subtotal' => 50,
+            'description' => 'Cargo adicional',
+        ]);
+
+        $this->assertDatabaseHas('ticket_details', [
+            'ticket_id' => $ticket->id,
+            'type' => 'extra',
+            'description' => 'Cargo adicional',
+        ]);
+    }
+}
+

--- a/tests/Feature/WasherChangePaidTicketTest.php
+++ b/tests/Feature/WasherChangePaidTicketTest.php
@@ -1,0 +1,89 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Washer;
+use App\Models\Service;
+use App\Models\VehicleType;
+use App\Models\Ticket;
+use App\Models\TicketWash;
+use App\Models\TicketDetail;
+use App\Models\WasherMovement;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WasherChangePaidTicketTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_change_washer_after_payment(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $washerA = Washer::create(['name' => 'A', 'pending_amount' => 0, 'active' => true]);
+        $washerB = Washer::create(['name' => 'B', 'pending_amount' => 0, 'active' => true]);
+        $vehicleType = VehicleType::create(['name' => 'Car']);
+        $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
+
+        $ticket = Ticket::create([
+            'user_id' => $user->id,
+            'vehicle_type_id' => $vehicleType->id,
+            'vehicle_id' => null,
+            'customer_name' => 'Cliente',
+            'customer_cedula' => null,
+            'total_amount' => 0,
+            'paid_amount' => 0,
+            'change' => 0,
+            'discount_total' => 0,
+            'payment_method' => 'efectivo',
+            'bank_account_id' => null,
+            'washer_pending_amount' => 0,
+            'canceled' => false,
+            'cancel_reason' => null,
+            'pending' => false,
+            'paid_at' => now(),
+        ]);
+
+        $wash = TicketWash::create([
+            'ticket_id' => $ticket->id,
+            'washer_id' => $washerA->id,
+            'vehicle_id' => null,
+            'vehicle_type_id' => $vehicleType->id,
+            'washer_paid' => true,
+            'tip' => 10,
+        ]);
+
+        TicketDetail::create([
+            'ticket_id' => $ticket->id,
+            'ticket_wash_id' => $wash->id,
+            'type' => 'service',
+            'service_id' => $service->id,
+            'product_id' => null,
+            'drink_id' => null,
+            'quantity' => 1,
+            'unit_price' => 0,
+            'discount_amount' => 0,
+            'subtotal' => 0,
+        ]);
+
+        WasherMovement::create([
+            'washer_id' => $washerA->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 10,
+            'description' => '[P] Test',
+            'paid' => true,
+        ]);
+
+        $response = $this->actingAs($user)->from(route('tickets.index'))->put(route('tickets.update', $ticket), [
+            'washers' => [ $wash->id => $washerB->id ],
+            'payment_method' => 'efectivo',
+            'bank_account_id' => null,
+        ]);
+
+        $response->assertSessionHasErrors('washers');
+        $this->assertEquals($washerA->id, $wash->fresh()->washer_id);
+        $this->assertDatabaseMissing('washer_movements', [
+            'washer_id' => $washerB->id,
+            'ticket_id' => $ticket->id,
+        ]);
+    }
+}

--- a/tests/Feature/WasherDebtTest.php
+++ b/tests/Feature/WasherDebtTest.php
@@ -9,6 +9,7 @@ use App\Models\Ticket;
 use App\Models\TicketDetail;
 use App\Models\WasherPayment;
 use App\Models\WasherMovement;
+use App\Models\TicketWash;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Carbon\Carbon;
@@ -34,7 +35,6 @@ class WasherDebtTest extends TestCase
 
         $ticket = Ticket::create([
             'user_id' => $user->id,
-            'washer_id' => $washer->id,
             'vehicle_type_id' => $vehicleType->id,
             'vehicle_id' => null,
             'customer_name' => 'Cliente',
@@ -52,8 +52,18 @@ class WasherDebtTest extends TestCase
             'paid_at' => now(),
         ]);
 
+        $wash = TicketWash::create([
+            'ticket_id' => $ticket->id,
+            'washer_id' => $washer->id,
+            'vehicle_id' => null,
+            'vehicle_type_id' => $vehicleType->id,
+            'washer_paid' => false,
+            'tip' => 0,
+        ]);
+
         TicketDetail::create([
             'ticket_id' => $ticket->id,
+            'ticket_wash_id' => $wash->id,
             'type' => 'service',
             'service_id' => $service->id,
             'product_id' => null,

--- a/tests/Feature/WasherDebtTest.php
+++ b/tests/Feature/WasherDebtTest.php
@@ -87,7 +87,7 @@ class WasherDebtTest extends TestCase
         $this->actingAs($user)
             ->post(route('tickets.cancel', $ticket), [
                 'cancel_reason' => 'test',
-                'pay_commission' => 'no',
+                'pay_washer' => 'no',
             ]);
 
         $this->assertDatabaseHas('washer_movements', [

--- a/tests/Feature/WasherReassignmentTipTest.php
+++ b/tests/Feature/WasherReassignmentTipTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Washer;
+use App\Models\Ticket;
+use App\Models\TicketWash;
+use App\Models\WasherMovement;
+
+class WasherReassignmentTipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_reassigning_washer_moves_tip()
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $washerA = Washer::create(['name' => 'A', 'pending_amount' => 0, 'active' => true]);
+        $washerB = Washer::create(['name' => 'B', 'pending_amount' => 0, 'active' => true]);
+
+        $ticket = Ticket::create([
+            'user_id' => $user->id,
+            'total_amount' => 0,
+            'paid_amount' => 0,
+            'payment_method' => 'efectivo',
+            'washer_pending_amount' => 0,
+            'customer_name' => 'Cliente',
+            'pending' => false,
+            'canceled' => false,
+        ]);
+
+        $wash = TicketWash::create([
+            'ticket_id' => $ticket->id,
+            'washer_id' => $washerA->id,
+            'vehicle_id' => null,
+            'vehicle_type_id' => null,
+            'washer_paid' => false,
+            'tip' => 20,
+        ]);
+        \App\Models\TicketDetail::create([
+            'ticket_id' => $ticket->id,
+            'ticket_wash_id' => $wash->id,
+            'type' => 'service',
+            'service_id' => null,
+            'product_id' => null,
+            'drink_id' => null,
+            'quantity' => 1,
+            'unit_price' => 0,
+            'discount_amount' => 0,
+            'subtotal' => 0,
+        ]);
+
+        WasherMovement::create([
+            'washer_id' => $washerA->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 20,
+            'description' => '[P] Test',
+        ]);
+        $washerA->increment('pending_amount', 120);
+
+        $response = $this->actingAs($user)->put(route('tickets.update', $ticket), [
+            'washers' => [ $wash->id => $washerB->id ],
+            'payment_method' => 'efectivo',
+            'bank_account_id' => null,
+        ]);
+
+        $washerA->refresh();
+        $washerB->refresh();
+        $wash->refresh();
+
+        $this->assertEquals(0, $washerA->pending_amount);
+        $this->assertEquals(120, $washerB->pending_amount);
+        $this->assertEquals($washerB->id, $wash->washer_id);
+        $this->assertDatabaseMissing('washer_movements', [
+            'washer_id' => $washerA->id,
+            'ticket_id' => $ticket->id,
+        ]);
+        $this->assertDatabaseHas('washer_movements', [
+            'washer_id' => $washerB->id,
+            'ticket_id' => $ticket->id,
+            'amount' => 20,
+        ]);
+    }
+}

--- a/tests/Feature/WasherUnassignedPaidTicketTest.php
+++ b/tests/Feature/WasherUnassignedPaidTicketTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Ticket;
+use App\Models\TicketWash;
+
+class WasherUnassignedPaidTicketTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_paid_unassigned_wash_counts_towards_totals()
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $ticket = Ticket::create([
+            'user_id' => $user->id,
+            'total_amount' => 0,
+            'paid_amount' => 0,
+            'payment_method' => 'efectivo',
+            'washer_pending_amount' => 150,
+            'customer_name' => 'Cliente',
+            'pending' => false,
+            'canceled' => false,
+            'paid_at' => now(),
+        ]);
+
+        TicketWash::create([
+            'ticket_id' => $ticket->id,
+            'washer_id' => null,
+            'vehicle_id' => null,
+            'vehicle_type_id' => null,
+            'washer_paid' => false,
+            'tip' => 50,
+        ]);
+
+        $date = now()->toDateString();
+        $response = $this->actingAs($user)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->get(route('washers.index', ['start' => $date, 'end' => $date, 'ajax' => 1]));
+
+        $response->assertSee('RD$ 150.00');
+
+        $dash = $this->actingAs($user)
+            ->get("/dashboard?start=$date&end=$date");
+
+        $this->assertEquals(150, $dash->viewData('washerPayDue'));
+    }
+}

--- a/tests/Feature/WasherUnassignedTotalTest.php
+++ b/tests/Feature/WasherUnassignedTotalTest.php
@@ -39,13 +39,18 @@ class WasherUnassignedTotalTest extends TestCase
             'vehicle_id' => null,
             'vehicle_type_id' => null,
             'washer_paid' => false,
+            'tip' => 50,
         ]);
 
         $response = $this->actingAs($user)
             ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
             ->get(route('washers.index', ['ajax' => 1]));
 
-        $response->assertSee('Pendiente de asignar');
-        $response->assertSee('RD$ 100.00');
+        $response->assertSeeInOrder([
+            'Total adeudado',
+            'RD$ 150.00',
+            'Pendiente de asignar',
+            'RD$ 150.00',
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- allow entering washer tips per wash and record payouts
- support additional charges on tickets
- track tip payments for washers

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68a93ecd9cb0832aa129e15b40a41a72