### PR TITLE
Add product and updated drink seeders

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
             VehicleSeeder::class,
             ExtraVehicleSeeder::class,
             DrinkSeeder::class,
+            ProductSeeder::class,
             BankAccountSeeder::class,
             UserSeeder::class,
         ]);

--- a/database/seeders/DrinkSeeder.php
+++ b/database/seeders/DrinkSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DrinkSeeder extends Seeder
@@ -14,26 +13,44 @@ class DrinkSeeder extends Seeder
     {
         $drinks = [
             [
-                'name' => 'Margarita',
+                'name' => 'Margarita de limón',
                 'ingredients' => 'Tequila, sal y limón.',
                 'price' => 300,
                 'active' => true,
             ],
             [
-                'name' => 'Mojito',
-                'ingredients' => 'Hoja de menta, limón, ron blanco, azúcar y 7up.',
-                'price' => 300,
-                'active' => true,
-            ],
-            [
-                'name' => 'Sangría',
-                'ingredients' => 'Vino tinto, jugo de naranja, jugo de limón y soda (agua con gas).',
+                'name' => 'Mojito de limón',
+                'ingredients' => '*',
                 'price' => 350,
                 'active' => true,
             ],
             [
-                'name' => 'Gin Tonic',
-                'ingredients' => 'Ginebra y agua tónica, decorada con aceitunas.',
+                'name' => 'Sangría',
+                'ingredients' => 'Vino tinto, jugo de naranja, jugo de limón y soda ...',
+                'price' => 350,
+                'active' => true,
+            ],
+            [
+                'name' => 'Mojito de Coco',
+                'ingredients' => '*',
+                'price' => 350,
+                'active' => true,
+            ],
+            [
+                'name' => 'Margarita de fresa',
+                'ingredients' => '*',
+                'price' => 350,
+                'active' => true,
+            ],
+            [
+                'name' => 'Caipiriña',
+                'ingredients' => '*',
+                'price' => 350,
+                'active' => true,
+            ],
+            [
+                'name' => 'Piña Colada',
+                'ingredients' => '*',
                 'price' => 350,
                 'active' => true,
             ],

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Product;
+
+class ProductSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $products = [
+            ['name' => 'Presidente Light', 'price' => 150.00, 'stock' => 42],
+            ['name' => 'Presidente Dura Peq.', 'price' => 150.00, 'stock' => 56],
+            ['name' => 'Presidente Dura Med.', 'price' => 250.00, 'stock' => 18],
+            ['name' => 'Cerveza One Peq.', 'price' => 150.00, 'stock' => 21],
+            ['name' => 'Cerveza Modelo', 'price' => 200.00, 'stock' => 18],
+            ['name' => 'Cerveza Smirnof', 'price' => 200.00, 'stock' => 9],
+            ['name' => 'Cerveza Heiniken', 'price' => 200.00, 'stock' => 24],
+            ['name' => 'Cerveza Corona', 'price' => 200.00, 'stock' => 16],
+            ['name' => 'Cerveza Desperado', 'price' => 200.00, 'stock' => 4],
+            ['name' => 'Cerveza Stella', 'price' => 200.00, 'stock' => 10],
+            ['name' => 'Coca-Cola 20 Onz.', 'price' => 90.00, 'stock' => 15],
+            ['name' => 'Gatorade Peq.', 'price' => 60.00, 'stock' => 6],
+            ['name' => '7-Up 20 Onz.', 'price' => 90.00, 'stock' => 14],
+            ['name' => 'Botella Agua Planeta Azul - 20 Onz.', 'price' => 30.00, 'stock' => 17],
+            ['name' => 'Botella de Agua Tonica', 'price' => 90.00, 'stock' => 12],
+            ['name' => 'Botella Agua Enrriquillo', 'price' => 90.00, 'stock' => 10],
+            ['name' => 'Jugo Motts', 'price' => 150.00, 'stock' => 15],
+            ['name' => 'Whisky Black Label 12 años', 'price' => 3200.00, 'stock' => 1],
+            ['name' => 'Botella Agua Perrier', 'price' => 150.00, 'stock' => 4],
+            ['name' => 'Vodka Stoli', 'price' => 1200.00, 'stock' => 1],
+            ['name' => 'Whisky Old Parr', 'price' => 3800.00, 'stock' => 4],
+            ['name' => 'Ron Brugal Doble Reserva', 'price' => 1200.00, 'stock' => 2],
+            ['name' => 'Vino Frontera', 'price' => 1000.00, 'stock' => 1],
+            ['name' => 'Vino Secret', 'price' => 1000.00, 'stock' => 1],
+            ['name' => 'Cidra Rose', 'price' => 900.00, 'stock' => 1],
+            ['name' => 'Ron Brugal Leyenda', 'price' => 2300.00, 'stock' => 1],
+            ['name' => 'Vodka Absolute', 'price' => 1600.00, 'stock' => 1],
+            ['name' => 'Fireball Mini Shot', 'price' => 150.00, 'stock' => 10],
+            ['name' => 'Serpis Lata Aceitunas Verdes - 120g', 'price' => 150.00, 'stock' => 0],
+            ['name' => 'Serpis Lata Aceituna Negras sin hueso - 200g', 'price' => 200.00, 'stock' => 2],
+            ['name' => 'La Explanda Lata Aceitunas Queso Azul - 350g', 'price' => 350.00, 'stock' => 1],
+            ['name' => 'Pinos Ambientadores - Little Trees', 'price' => 150.00, 'stock' => 5],
+            ['name' => 'Ambientadores - KIA', 'price' => 100.00, 'stock' => 2],
+            ['name' => 'Ambientador - Manzana Azul', 'price' => 250.00, 'stock' => 2],
+            ['name' => 'Ambientador Kuksuan', 'price' => 200.00, 'stock' => 0],
+            ['name' => 'Lanilla Micrfibra de colores', 'price' => 100.00, 'stock' => 5],
+            ['name' => 'Mani al granel', 'price' => 100.00, 'stock' => 1],
+            ['name' => 'Tridents', 'price' => 100.00, 'stock' => 6],
+            ['name' => 'Vasos 10 Onz.', 'price' => 180.00, 'stock' => 0],
+            ['name' => 'Servilleta 500 Ud', 'price' => 230.00, 'stock' => 1],
+            ['name' => 'Whisky Double Black', 'price' => 5500.00, 'stock' => 2],
+        ];
+
+        foreach ($products as $product) {
+            Product::updateOrCreate(['name' => $product['name']], $product);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ProductSeeder with current catalog entries
- update DrinkSeeder to latest drink list
- include ProductSeeder in DatabaseSeeder

## Testing
- `php artisan test`
- `php artisan migrate:fresh --seed --env=testing`

------
https://chatgpt.com/codex/tasks/task_e_68b1f48a0c18832aaf60f9957d30a304