### PR TITLE
Enable petty cash configuration and backdated expenses

### DIFF
--- a/app/Models/PettyCashExpense.php
+++ b/app/Models/PettyCashExpense.php
@@ -8,7 +8,7 @@ class PettyCashExpense extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id', 'description', 'amount'];
+    protected $fillable = ['user_id', 'description', 'amount', 'created_at', 'updated_at'];
 
     public function user()
     {

--- a/app/Models/PettyCashSetting.php
+++ b/app/Models/PettyCashSetting.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PettyCashSetting extends Model
+{
+    protected $fillable = ['amount', 'effective_date'];
+
+    public static function amountForDate($date)
+    {
+        return static::where('effective_date', '<=', $date)
+            ->orderByDesc('effective_date')
+            ->value('amount') ?? 3200;
+    }
+}

--- a/database/migrations/2025_09_14_184512_create_petty_cash_settings_table.php
+++ b/database/migrations/2025_09_14_184512_create_petty_cash_settings_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('petty_cash_settings', function (Blueprint $table) {
+            $table->id();
+            $table->decimal('amount', 10, 2);
+            $table->date('effective_date');
+            $table->timestamps();
+        });
+
+        // valor inicial por defecto
+        DB::table('petty_cash_settings')->insert([
+            'amount' => 3200,
+            'effective_date' => '2020-01-01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('petty_cash_settings');
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -6,6 +6,9 @@
     body {
         @apply bg-gray-50 text-gray-800;
     }
+    [x-cloak] {
+        display: none !important;
+    }
 }
 
 @layer components {

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -58,7 +58,7 @@
             <p>Efectivo: <strong>RD$ {{ number_format($cashTotal, 2) }}</strong></p>
             <p>Transferencias: <strong>RD$ {{ number_format($transferTotal, 2) }}</strong></p>
             <p>Total facturado: <strong>RD$ {{ number_format($invoicedTotal, 2) }}</strong></p>
-            <p>Caja chica: <strong>RD$ 3,200.00</strong></p>
+            <p>Caja chica: <strong>RD$ {{ number_format($pettyCashAmount, 2) }}</strong></p>
             <p>Gastos de caja chica: <strong>RD$ {{ number_format($pettyCashTotal, 2) }}</strong></p>
             <p>Para lavadores: <strong>RD$ {{ number_format($washerPayDue, 2) }}</strong></p>
             <p>Ventas de lavados: RD$ {{ number_format($serviceTotal, 2) }}</p>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -1,4 +1,4 @@
-<aside x-cloak :class="{'-translate-x-full': !sidebarOpen}" class="fixed inset-y-0 left-0 z-40 w-64 bg-white border-r border-gray-200 transform transition-transform duration-200 md:relative md:translate-x-0 md:w-48">
+<aside :class="{'translate-x-0': sidebarOpen}" class="fixed inset-y-0 left-0 z-40 w-64 bg-white border-r border-gray-200 transform transition-transform duration-200 -translate-x-full md:relative md:translate-x-0 md:w-48">
     <div class="p-4 h-full overflow-y-auto">
         <nav class="space-y-2">
             <a href="{{ route('dashboard') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('dashboard') ? 'bg-gray-200' : '' }}">

--- a/resources/views/petty_cash/create.blade.php
+++ b/resources/views/petty_cash/create.blade.php
@@ -7,7 +7,7 @@
 
     <div class="py-4">
         <div class="max-w-2xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
-            <p class="mb-4 text-sm text-gray-700">Disponible hoy: RD$ {{ number_format($remaining, 2) }}</p>
+            <p class="mb-4 text-sm text-gray-700">Monto diario: RD$ {{ number_format($pettyCashAmount, 2) }} | Disponible hoy: RD$ {{ number_format($remaining, 2) }}</p>
             @if ($errors->any())
                 <div class="mb-4 text-sm text-red-600">
                     <ul class="list-disc list-inside">
@@ -28,6 +28,11 @@
                 <div class="mb-4">
                     <label for="amount" class="block font-medium text-sm text-gray-700">Monto</label>
                     <input type="number" step="0.01" name="amount" id="amount" required class="form-input w-full rounded border-gray-300 shadow-sm mt-1">
+                </div>
+
+                <div class="mb-4">
+                    <label for="date" class="block font-medium text-sm text-gray-700">Fecha</label>
+                    <input type="date" name="date" id="date" max="{{ now()->toDateString() }}" value="{{ now()->toDateString() }}" required class="form-input w-full rounded border-gray-300 shadow-sm mt-1">
                 </div>
 
                 <div class="flex justify-end">

--- a/resources/views/petty_cash/index.blade.php
+++ b/resources/views/petty_cash/index.blade.php
@@ -54,7 +54,7 @@
         <div x-html="tableHtml"></div>
 
         @if(Auth::user()->role === 'admin')
-        <div x-show="showFundModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+        <div x-show="showFundModal" x-cloak class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
             <div class="bg-white p-6 rounded shadow w-80" @click.away="showFundModal=false">
                 <h3 class="text-lg font-semibold mb-4">Configurar Caja Chica</h3>
                 <form method="POST" action="{{ route('petty-cash.update-fund') }}">

--- a/resources/views/petty_cash/index.blade.php
+++ b/resources/views/petty_cash/index.blade.php
@@ -5,7 +5,7 @@
         </h2>
     </x-slot>
 
-    <div x-data="filterTable('{{ route('petty-cash.index') }}')" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+    <div x-data="filterTable('{{ route('petty-cash.index') }}', { showFundModal: false })" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
@@ -27,13 +27,53 @@
                 </div>
             </form>
             <a href="{{ route('petty-cash.create') }}" class="btn-primary">Nuevo Gasto</a>
+            @if(Auth::user()->role === 'admin')
+            <button type="button" class="btn-secondary" @click="showFundModal = true">Configurar Monto</button>
+            @endif
         </div>
 
+        @if ($errors->any())
+            <div class="mb-4 text-sm text-red-600">
+                <ul class="list-disc list-inside">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+        @if(session('success'))
+            <div class="mb-4 text-sm text-green-600">{{ session('success') }}</div>
+        @endif
+
         <div class="mb-4 text-sm text-gray-700">
+            Monto diario: RD$ {{ number_format($pettyCashAmount, 2) }} |
             Gastado hoy: RD$ {{ number_format($todayTotal, 2) }} |
             Disponible hoy: RD$ {{ number_format($remaining, 2) }}
         </div>
 
         <div x-html="tableHtml"></div>
+
+        @if(Auth::user()->role === 'admin')
+        <div x-show="showFundModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+            <div class="bg-white p-6 rounded shadow w-80" @click.away="showFundModal=false">
+                <h3 class="text-lg font-semibold mb-4">Configurar Caja Chica</h3>
+                <form method="POST" action="{{ route('petty-cash.update-fund') }}">
+                    @csrf
+                    <div class="mb-4">
+                        <label class="block text-sm">Monto</label>
+                        <input type="number" step="0.01" name="amount" value="{{ $pettyCashAmount }}" class="form-input w-full" required>
+                    </div>
+                    <div class="mb-4 flex items-center gap-2">
+                        <input type="checkbox" name="apply_today" value="1" checked class="form-checkbox">
+                        <span class="text-sm">Aplicar desde hoy</span>
+                    </div>
+                    <div class="flex justify-end gap-2">
+                        <button type="button" class="px-3 py-1 bg-gray-300 rounded" @click="showFundModal=false">Cancelar</button>
+                        <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded">Guardar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        @endif
     </div>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('bank-accounts', \App\Http\Controllers\BankAccountController::class);
     Route::get('appearance', [AppearanceController::class, 'index'])->name('appearance.index');
     Route::post('appearance', [AppearanceController::class, 'store'])->name('appearance.store');
+    Route::post('petty-cash/fund', [PettyCashExpenseController::class, 'updateFund'])->name('petty-cash.update-fund');
 });
 Route::middleware(['auth', 'role:admin,cajero'])->group(function () {
     Route::resource('products', ProductController::class);


### PR DESCRIPTION
## Summary
- Track petty cash fund via `petty_cash_settings` table
- Allow registering petty cash expenses for past dates with balance validation
- Deduct petty cash expenses from dashboard cash totals and provide admin fund adjustment modal

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68c7446c25a4832a9c7dcdec99123bf2